### PR TITLE
docs: Fix a few typos

### DIFF
--- a/akshare/utils/demjson.py
+++ b/akshare/utils/demjson.py
@@ -4690,7 +4690,7 @@ class JSON(object):
                     break  # will report error futher down because done==False
                 elif c == ',':
                     if not saw_value:
-                        # no preceeding value, an elided (omitted) element
+                        # no preceding value, an elided (omitted) element
                         if isdict:
                             state.push_error('Can not omit elements of an object (dictionary)',
                                              outer_position=start_position,
@@ -5930,7 +5930,7 @@ MORE INFORMATION:
 
           * program_name  - the name of the program, usually sys.argv[0]
           * stdin   - the file object to use for input, default sys.stdin
-          * stdout  - the file object to use for outut, default sys.stdout
+          * stdout  - the file object to use for output, default sys.stdout
           * stderr  - the file object to use for error output, default sys.stderr
 
         After creating an instance, you typically call the main() method.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # Configuration file for the Sphinx documentation builder.
-# sphinx-build -b html . bulid
+# sphinx-build -b html . build
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html


### PR DESCRIPTION
There are small typos in:
- akshare/utils/demjson.py
- docs/conf.py

Fixes:
- Should read `preceding` rather than `preceeding`.
- Should read `output` rather than `outut`.
- Should read `build` rather than `bulid`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md