### PR TITLE
Fix stock_info_sh_name_code COMPANY_STATUS header

### DIFF
--- a/akshare/stock/stock_info.py
+++ b/akshare/stock/stock_info.py
@@ -138,7 +138,7 @@ def stock_info_sh_name_code(indicator: str = "主板A股") -> pd.DataFrame:
         "CSRC_CODE": "",
         "STOCK_CODE": "",
         "sqlId": "COMMON_SSE_CP_GPJCTPZ_GPLB_GP_L",
-        "COMPANY_STATUS": "2, 4, 5, 7, 8",
+        "COMPANY_STATUS": "2,4,5,7,8",
         "type": "inParams",
         "isPagination": "true",
         "pageHelp.cacheSize": "1",


### PR DESCRIPTION
Fix #2558 for ST type listing

before
```
6   600077   宋都股份    宋都股份  1997-05-20
7   600079   人福医药    人福医药  1997-06-06
```
after
```
6   600077   宋都股份   宋都股份  1997-05-20
7   600078  *ST澄星  *ST澄星  1997-06-27
8   600079   人福医药   人福医药  1997-06-06
```



