### PR TITLE
解决无法解析数据问题

### DIFF
--- a/akshare/economic/macro_other.py
+++ b/akshare/economic/macro_other.py
@@ -120,7 +120,7 @@ def index_vix(
     }
     headers = {
         "accept": "*/*",
-        "accept-encoding": "gzip, deflate, br",
+        "accept-encoding": "",
         "accept-language": "zh-CN,zh;q=0.9,en;q=0.8",
         "cache-control": "no-cache",
         "origin": "https://datacenter.jin10.com",


### PR DESCRIPTION
由于请求头中带有`accept-encoding`会导致接口下发的数据有可能会进行压缩，但是读取数据的时候，并没有进行解压缩，就会导致解码异常，最简单的方法就是去掉这个请求头