### PR TITLE
解决代号冲突，如平安银行与上证指数

### DIFF
--- a/akshare/stock_feature/stock_hist_em.py
+++ b/akshare/stock_feature/stock_hist_em.py
@@ -917,7 +917,7 @@ def stock_zh_a_hist(
         "end": end_date,
         "_": "1623766962675",
     }
-    r = requests.get(url, params=params, proxies={'http': 'http://127.0.0.1:8080'}, verify=False)
+    r = requests.get(url, params=params)
     data_json = r.json()
     if not (data_json["data"] and data_json["data"]["klines"]):
         return pd.DataFrame()


### PR DESCRIPTION
平安银行和上证指数都是000001 板块不同 通过原示例代码发现无法获取到上证指数

```
import akshare as ak

if __name__ == '__main__':
    stock_zh_a_minute_df = ak.stock_zh_a_hist(symbol='000001', period='daily')
    print(stock_zh_a_minute_df)
```

现修改增加不同板块，解决冲突