### PR TITLE
fix(futures/cons.py): fix ResourceWarning

### DIFF
--- a/akshare/futures/cons.py
+++ b/akshare/futures/cons.py
@@ -496,7 +496,8 @@ def get_calendar():
     """
     setting_file_name = "calendar.json"
     setting_file_path = get_json_path(setting_file_name, __file__)
-    data_json = json.load(open(setting_file_path, "r"))
+    with open(setting_file_path, "r") as f:
+        data_json = json.load(f)
     return data_json
 
 


### PR DESCRIPTION
The problem is file open without close, warning log below:
```
/home/tsing/.local/lib/python3.10/site-packages/akshare/futures/cons.py:498: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/tsing/.local/lib/python3.10/site-packages/akshare/file_fold/calendar.json' mode='r' encoding='UTF-8'>
  data_json = json.load(open(setting_file_path, "r"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/tsing/.local/lib/python3.10/site-packages/akshare/futures/cons.py:498: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/tsing/.local/lib/python3.10/site-packages/akshare/file_fold/calendar.json' mode='r' encoding='UTF-8'>
  data_json = json.load(open(setting_file_path, "r"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/tsing/.local/lib/python3.10/site-packages/akshare/futures/cons.py:498: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/tsing/.local/lib/python3.10/site-packages/akshare/file_fold/calendar.json' mode='r' encoding='UTF-8'>
  data_json = json.load(open(setting_file_path, "r"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/tsing/.local/lib/python3.10/site-packages/akshare/futures/cons.py:498: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/tsing/.local/lib/python3.10/site-packages/akshare/file_fold/calendar.json' mode='r' encoding='UTF-8'>
  data_json = json.load(open(setting_file_path, "r"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/tsing/.local/lib/python3.10/site-packages/akshare/futures/cons.py:498: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/tsing/.local/lib/python3.10/site-packages/akshare/file_fold/calendar.json' mode='r' encoding='UTF-8'>
  data_json = json.load(open(setting_file_path, "r"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```