### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         "websocket-client>=0.56.0",
         "html5lib>=1.0.1",
         "xlrd>=1.2.0",
-        "urllib3>=1.25.8",
+        "urllib3~=1.26.15",
         "tqdm>=4.43.0",
         "openpyxl>=3.0.3",
         "jsonpath>=0.82",


### PR DESCRIPTION
在windows server 2022中测试, 2.0版本的urllib3会报错

Traceback (most recent call last):
  File "C:\Users\Administrator\Developer\xtrader\trader-data\trader_data\run.py", line 3, in <module>
    from trader_data.stock import stock_list, stock_day, stock_dividend, stock_share_change, stock_adj, stock_day_ext, \
  File "c:\users\administrator\developer\xtrader\trader-data\trader_data\stock\stock_day.py", line 3, in <module>
    import akshare as ak
  File "C:\Users\Administrator\Developer\xtrader\akshare_\akshare\__init__.py", line 3727, in <module>
    from akshare.futures.futures_sgx_daily import futures_sgx_daily
  File "C:\Users\Administrator\Developer\xtrader\akshare_\akshare\futures\futures_sgx_daily.py", line 17, in <module>
    from akshare.index.index_investing import index_investing_global
  File "C:\Users\Administrator\Developer\xtrader\akshare_\akshare\index\index_investing.py", line 10, in <module>
    import cfscrape
  File "C:\Users\Administrator\scoop\apps\miniconda3\current\envs\xtrader\lib\site-packages\cfscrape\__init__.py", line 19, in <module>
    from urllib3.util.ssl_ import create_urllib3_context, DEFAULT_CIPHERS
ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' 