### PR TITLE
implement issue #4003

### DIFF
--- a/akshare/stock_feature/stock_hist_em.py
+++ b/akshare/stock_feature/stock_hist_em.py
@@ -992,6 +992,7 @@ def stock_zh_a_hist(
     start_date: str = "19700101",
     end_date: str = "20500101",
     adjust: str = "",
+    timeout: float = None,
 ) -> pd.DataFrame:
     """
     东方财富网-行情首页-沪深京 A 股-每日行情
@@ -1006,6 +1007,8 @@ def stock_zh_a_hist(
     :type end_date: str
     :param adjust: choice of {"qfq": "前复权", "hfq": "后复权", "": "不复权"}
     :type adjust: str
+    :param timeout: choice of None or a positive float number
+    :type timeout: float
     :return: 每日行情
     :rtype: pandas.DataFrame
     """
@@ -1024,7 +1027,7 @@ def stock_zh_a_hist(
         "end": end_date,
         "_": "1623766962675",
     }
-    r = requests.get(url, params=params)
+    r = requests.get(url, params=params, timeout=timeout)
     data_json = r.json()
     if not (data_json["data"] and data_json["data"]["klines"]):
         return pd.DataFrame()

--- a/akshare/stock_feature/stock_hist_em.py
+++ b/akshare/stock_feature/stock_hist_em.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 """
-Date: 2023/6/7 16:26
+Date: 2023/7/24 01:36
 Desc: 东方财富网-行情首页-沪深京 A 股
 """
 import requests

--- a/docs/data/stock/stock.md
+++ b/docs/data/stock/stock.md
@@ -1024,6 +1024,7 @@ print(stock_zh_a_spot_df)
 | start_date | str | start_date='20210301'; 开始查询的日期                           |
 | end_date   | str | end_date='20210616'; 结束查询的日期                             |
 | adjust     | str | 默认返回不复权的数据; qfq: 返回前复权后的数据; hfq: 返回后复权后的数据               |
+| timeout    | float | timeout=None; 默认不设置超时参数                          |
 
 **股票数据复权**
 


### PR DESCRIPTION
Setting timeout=None so the API is backwards compatible.

We can also set it to a positive float to indicate number of seconds for timeout so the request call is non-blocking.
- Example: timeout=30 means requests.get will return within 30 seconds.