### PR TITLE
add delisted comp notice

### DIFF
--- a/akshare/stock_fundamental/stock_notice.py
+++ b/akshare/stock_fundamental/stock_notice.py
@@ -36,7 +36,7 @@ def stock_notice_report(symbol: str = "全部", date: str = "20220511") -> pd.Da
         "sr": "-1",
         "page_size": "100",
         "page_index": "1",
-        "ann_type": "SHA,CYB,SZA,BJA",
+        "ann_type": "A",
         "client_source": "web",
         "f_node": report_map[symbol],
         "s_node": "0",


### PR DESCRIPTION
ann_type如果按原始的填写上交所、深交所、创业板、科创板，在取历史日期的时候，会漏掉已退市股票的公告信息
直接填写"A"可以返回完整的公告列表