### PR TITLE
新增接口stock_profile_cninfo

### DIFF
--- a/akshare/__init__.py
+++ b/akshare/__init__.py
@@ -2778,6 +2778,11 @@ from akshare.stock_feature.stock_hk_valuation_baidu import stock_hk_valuation_ba
 from akshare.stock.stock_profile_cninfo import stock_profile_cninfo
 
 """
+巨潮资讯-个股-上市相关
+"""
+from akshare.stock.stock_ipo_summary_cninfo import stock_ipo_summary_cninfo
+
+"""
 巨潮资讯-数据浏览器-筹资指标-公司配股实施方案
 """
 from akshare.stock.stock_allotment_cninfo import stock_allotment_cninfo

--- a/akshare/stock/stock_ipo_summary_cninfo.py
+++ b/akshare/stock/stock_ipo_summary_cninfo.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+"""
+Date: 2023/8/27 20:20
+Desc: 巨潮资讯-个股-上市相关
+http://webapi.cninfo.com.cn/#/company
+"""
+import pandas as pd
+import requests
+from py_mini_racer import py_mini_racer
+
+from akshare.datasets import get_ths_js
+
+
+def _get_file_content_ths(file: str = "cninfo.js") -> str:
+    """
+    获取 JS 文件的内容
+    :param file:  JS 文件名
+    :type file: str
+    :return: 文件内容
+    :rtype: str
+    """
+    setting_file_path = get_ths_js(file)
+    with open(setting_file_path) as f:
+        file_data = f.read()
+    return file_data
+
+
+def stock_ipo_summary_cninfo(symbol: str = "600030") -> pd.DataFrame:
+    """
+    巨潮资讯-个股-上市相关
+    http://webapi.cninfo.com.cn/#/company
+    :param symbol: 股票代码
+    :type symbol: str
+    :return: 上市相关
+    :rtype: pandas.DataFrame
+    :raise: Exception，如果服务器返回的数据无法被解析
+    """
+    url = "http://webapi.cninfo.com.cn/api/sysapi/p_sysapi1134"
+    params = {
+        "scode": symbol,
+    }
+    js_code = py_mini_racer.MiniRacer()
+    js_content = _get_file_content_ths("cninfo.js")
+    js_code.eval(js_content)
+    mcode = js_code.call("getResCode1")
+    headers = {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Host": "webapi.cninfo.com.cn",
+        "Accept-Enckey": mcode,
+        "Origin": "http://webapi.cninfo.com.cn",
+        "Pragma": "no-cache",
+        "Proxy-Connection": "keep-alive",
+        "Referer": "http://webapi.cninfo.com.cn/",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+    r = requests.post(url, params=params, headers=headers)
+    data_json = r.json()
+    columns = [
+        "股票代码",
+        "招股公告日期",
+        "中签率公告日",
+        "每股面值(元)",
+        "总发行数量(万股)",
+        "发行前每股净资产(元)",
+        "摊薄发行市盈率",
+        "募集资金净额(万元)",
+        "上网发行日期",
+        "上市日期",
+        "发行价格(元)",
+        "发行费用总额(万元)",
+        "发行后每股净资产(元)",
+        "上网发行中签率(%)",
+        "主承销商",
+    ]
+    count = data_json["count"]
+    if count == 1:
+        # 有上市相关的
+        redundant_json = data_json["records"][0]
+        records_json = {}
+        i = 0
+        for k, v in redundant_json.items():
+            if i == (len(redundant_json)):
+                break
+            records_json[k] = v
+            i += 1
+        del i
+        temp_df = pd.Series(records_json).to_frame().T
+        temp_df.columns = columns
+    elif count == 0:
+        # 没上市相关的
+        temp_df = pd.DataFrame(columns=columns)
+    else:
+        raise Exception("数据错误！")
+    return temp_df
+
+
+if __name__ == "__main__":
+    stock_ipo_summary_cninfo_df = stock_ipo_summary_cninfo(symbol="600030")
+    print(stock_ipo_summary_cninfo_df)

--- a/docs/data/stock/stock.md
+++ b/docs/data/stock/stock.md
@@ -8239,6 +8239,59 @@ print(stock_profile_cninfo_df)
 0  中信证券股份有限公司  ...  公司的前身中信证券有限责任公司是经中国人民银行银复[1995]313号文批准，由中信公司，中...
 ```
 
+#### 上市相关-巨潮资讯
+
+接口: stock_ipo_summary_cninfo
+
+目标地址: http://webapi.cninfo.com.cn/#/company
+
+描述: 巨潮资讯-个股-上市相关
+
+限量: 单次获取指定 symbol 的上市相关
+
+输入参数
+
+| 名称         | 类型  | 描述                    |
+|------------|-----|-----------------------|
+| symbol     | str | symbol="600030"       |
+
+输出参数
+
+| 名称   | 类型     | 描述  |
+|------|--------|-----|
+| 股票代码 | object | -   |
+| 招股公告日期 | object | -   |
+| 中签率公告日 | object | -   |
+| 每股面值(元) | object | -   |
+| 总发行数量(万股) | object | -   |
+| 发行前每股净资产(元) | object | -   |
+| 摊薄发行市盈率 | object | -   |
+| 募集资金净额(万元) | object | -   |
+| 上网发行日期 | object | -   |
+| 上市日期 | object | -   |
+| 发行价格(元) | object | -   |
+| 发行费用总额(万元) | object | -   |
+| 发行后每股净资产(元) | object | -   |
+| 上网发行中签率(%) | object | -   |
+| 主承销商 | object | -   |
+
+接口示例
+
+```python
+import akshare as ak
+
+stock_ipo_summary_cninfo_df = stock_ipo_summary_cninfo(symbol="600030")
+print(stock_ipo_summary_cninfo_df)
+```
+
+数据示例
+
+```
+     股票代码      招股公告日期 中签率公告日 每股面值(元) 总发行数量(万股) ...  主承销商
+0  600030  2002-12-13   None     1.0   40000.0   ...   广发证券股份有限公司
+```
+
+
 #### 资产负债表
 
 接口: stock_zcfz_em

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1138,6 +1138,8 @@
  "stock_allotment_cninfo"  # 配股实施方案-巨潮资讯
  # 巨潮资讯-个股-公司概况
  "stock_profile_cninfo"  # 巨潮资讯-个股-公司概况
+  # 巨潮资讯-个股-上市相关
+ "stock_ipo_summary_cninfo"  # 巨潮资讯-个股-上市相关
  # 百度股市通-港股-财务报表-估值数据
  "stock_hk_valuation_baidu"  # 百度股市通-港股-财务报表-估值数据
  # 百度股市通-A 股-财务报表-估值数据


### PR DESCRIPTION
新增接口stock_profile_cninfo，查询巨潮资讯-个股-上市相关，接口中包含上市公司的上市日期和发行价等上市信息。akshare中现其它接口的上市公司发行信息基本仅限于新股，新增该接口可用于所有股票（原网站巨潮资讯支持的所有股票）。