### PR TITLE
fix issue that page element does not exist on sina web page when the data set size is small

### DIFF
--- a/akshare/currency/currency_china_bank_sina.py
+++ b/akshare/currency/currency_china_bank_sina.py
@@ -79,7 +79,8 @@ def currency_boc_sina(
     r = requests.get(url, params=params)
     soup = BeautifulSoup(r.text, "lxml")
     soup.find(attrs={"id": "money_code"})
-    page_num = int(soup.find_all("a", attrs={"class": "page"})[-2].text)
+    page_element_list = soup.find_all("a", attrs={"class": "page"})
+    page_num = int(page_element_list[-2].text) if len(page_element_list) != 0 else 1
     big_df = pd.DataFrame()
     for page in tqdm(range(1, page_num + 1), leave=False):
         params.update({"page": page})


### PR DESCRIPTION
issue: when request data size is small, the page bar will not show on sina web page. so that this could cause a python error: "list index out of range"

example: https://biz.finance.sina.com.cn/forex/forex.php?startdate=2023-08-04&enddate=2023-08-13&money_code=EUR&type=0