### PR TITLE
fix: fix stock_ipo_summary_cninfo interface

### DIFF
--- a/akshare/stock/stock_ipo_summary_cninfo.py
+++ b/akshare/stock/stock_ipo_summary_cninfo.py
@@ -59,6 +59,8 @@ def stock_ipo_summary_cninfo(symbol: str = "600030") -> pd.DataFrame:
     }
     r = requests.post(url, params=params, headers=headers)
     data_json = r.json()
+    if not (data_json and data_json["records"]):
+        return pd.DataFrame()
     temp_df = pd.DataFrame.from_dict(data_json["records"][0], orient="index").T
     temp_df.columns = [
         "股票代码",


### PR DESCRIPTION
issue: when request data size is small, the page bar will not show on sina web page. so that this could cause a python error: "list index out of range"

example: stock_ipo_summary_cninfo(symbol="688555")