### PR TITLE
fix: fix stock_info_sh_delist interface

### DIFF
--- a/akshare/stock/stock_info.py
+++ b/akshare/stock/stock_info.py
@@ -275,13 +275,19 @@ def stock_info_bj_name_code() -> pd.DataFrame:
     return big_df
 
 
-def stock_info_sh_delist() -> pd.DataFrame:
+def stock_info_sh_delist(symbol: str = "全部") -> pd.DataFrame:
     """
     上海证券交易所-终止上市公司
     http://www.sse.com.cn/assortment/stock/list/delisting/
+    :param symbol: choice of {"全部", "沪市", "科创板"}
     :return: 终止上市公司
     :rtype: pandas.DataFrame
     """
+    symbol_map = {
+        "全部": "1,2,8",
+        "沪市": "1,2",
+        "科创板": "8",
+    }
     url = "http://query.sse.com.cn/commonQuery.do"
     headers = {
         "Accept": "*/*",
@@ -300,7 +306,7 @@ def stock_info_sh_delist() -> pd.DataFrame:
         "STOCK_CODE": "",
         "CSRC_CODE": "",
         "REG_PROVINCE": "",
-        "STOCK_TYPE": "1,2",
+        "STOCK_TYPE": symbol_map[symbol],
         "COMPANY_STATUS": "3",
         "type": "inParams",
         "pageHelp.cacheSize": "1",

--- a/docs/data/stock/stock.md
+++ b/docs/data/stock/stock.md
@@ -13735,9 +13735,9 @@ print(stock_staq_net_stop_df)
 
 输入参数
 
-| 名称  | 类型  | 描述  |
-|-----|-----|-----|
-| -   | -   | -   |
+| 名称    | 类型 | 描述                                            |
+|--------|-----|-------------------------------------------------|
+| symbol | str | symbol="全部"; choice of {"全部", "沪市", "科创板"} |
 
 输出参数
 
@@ -13753,7 +13753,7 @@ print(stock_staq_net_stop_df)
 ```python
 import akshare as ak
 
-stock_info_sh_delist_df = ak.stock_info_sh_delist()
+stock_info_sh_delist_df = ak.stock_info_sh_delist(symbol="全部")
 print(stock_info_sh_delist_df)
 ```
 


### PR DESCRIPTION
更新 `stock_info_sh_delist` - `暂停/终止上市-上证` 接口
* 增加参数 `symbol` 可同时获取 沪市和科创板数据，原本只能获取沪市数据