### PR TITLE
Update stock_restricted_release_queue_em when no data

### DIFF
--- a/akshare/stock_fundamental/stock_restricted_em.py
+++ b/akshare/stock_fundamental/stock_restricted_em.py
@@ -206,6 +206,8 @@ def stock_restricted_release_queue_em(symbol: str = "600000") -> pd.DataFrame:
     }
     r = requests.get(url, params=params)
     data_json = r.json()
+    if data_json["result"] is None:
+        return pd.DataFrame()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)
     temp_df["index"] = temp_df["index"] + 1


### PR DESCRIPTION
### Summary
Failed cases:
1. https://data.eastmoney.com/dxf/q/600761.html
2.  https://data.eastmoney.com/dxf/q/600197.html

For the above two stocks, it doesn't have any restriction release data. The function `stock_restricted_release_queue_em` throws exception.  Example response:
```
jQuery1123008162977699003626_1712487522181({
    "version": null,
    "result": null,
    "success": false,
    "message": "返回数据为空",
    "code": 9201
});
```

This PR is to return empty data frame when json response has no ["result"]["data"].

### Test
Tested when input is 600761 and 600197. I can get expected [] response.