### PR TITLE
防反爬功能的实装

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PROXY='http://t11289684233521:tgt415h4@a479.kdltps.com:15818/'

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-PROXY='http://t11289684233521:tgt415h4@a479.kdltps.com:15818/'
+PROXY='http://'

--- a/akshare/__init__.py
+++ b/akshare/__init__.py
@@ -2774,6 +2774,8 @@ if sys.version_info < (3, 9):
 
 del sys
 
+from akshare.request_config_manager import start_config, stop_config, change_proxy
+
 """
 申万宏源研究-申万指数-指数发布-基金指数-实时行情
 """

--- a/akshare/air/air_hebei.py
+++ b/akshare/air/air_hebei.py
@@ -18,6 +18,7 @@ from datetime import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -32,7 +33,8 @@ def air_quality_hebei(symbol: str = "唐山市") -> pd.DataFrame:
     """
     url = "http://110.249.223.67/server/api/CityPublishInfo/GetProvinceAndCityPublishData"
     params = {"publishDate": f"{datetime.today().strftime('%Y-%m-%d')} 16:00:00"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     json_data = r.json()
     city_list = pd.DataFrame.from_dict(json_data["cityPublishDatas"], orient="columns")[
         "CityName"

--- a/akshare/air/air_zhenqi.py
+++ b/akshare/air/air_zhenqi.py
@@ -15,6 +15,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.utils import demjson
@@ -78,7 +79,8 @@ def air_city_table() -> pd.DataFrame:
             "order": "DESC",
             "type": "DAY",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[1].iloc[1:, :]
         del temp_df["降序"]
         temp_df.reset_index(inplace=True)
@@ -136,7 +138,8 @@ def air_quality_watch_point(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/81.0.4044.122 Safari/537.36"
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(ctx.call("decode_result", data_text))
     temp_df = pd.DataFrame(data_json["rows"])
@@ -210,7 +213,8 @@ def air_quality_hist(
         "X-Requested-With": "XMLHttpRequest",
     }
     params = {"param": ctx.call("encode_param", need)}
-    r = requests.post(url, data=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=params, headers=headers, timeout=timeout)
     temp_text = ctx.call("decryptData", r.text)
     data_json = demjson.decode(ctx.call("b.decode", temp_text))
     temp_df = pd.DataFrame(data_json["result"]["data"]["rows"])
@@ -247,7 +251,8 @@ def air_quality_rank(date: str = "") -> pd.DataFrame:
             "order": "DESC",
             "type": "DAY",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         return pd.read_html(StringIO(r.text))[1].iloc[1:, :]
     elif len(date.split("-")) == 2:
         params = {
@@ -256,7 +261,8 @@ def air_quality_rank(date: str = "") -> pd.DataFrame:
             "order": "DESC",
             "type": "MONTH",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         return pd.read_html(StringIO(r.text))[2].iloc[1:, :]
     elif len(date.split("-")) == 1 and date != "实时":
         params = {
@@ -265,7 +271,8 @@ def air_quality_rank(date: str = "") -> pd.DataFrame:
             "order": "DESC",
             "type": "YEAR",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         return pd.read_html(StringIO(r.text))[3].iloc[1:, :]
     if date == "实时":
         params = {
@@ -273,7 +280,8 @@ def air_quality_rank(date: str = "") -> pd.DataFrame:
             "order": "DESC",
             "type": "MONTH",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         return pd.read_html(StringIO(r.text))[0].iloc[1:, :]
 
 

--- a/akshare/air/sunrise_tad.py
+++ b/akshare/air/sunrise_tad.py
@@ -10,6 +10,7 @@ from io import StringIO
 import pandas as pd
 import pypinyin
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def sunrise_city_list() -> list:
@@ -20,7 +21,8 @@ def sunrise_city_list() -> list:
     :rtype: list
     """
     url = "https://www.timeanddate.com/astronomy/china"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     city_list = []
     china_city_one_df = pd.read_html(StringIO(r.text))[1]
     china_city_two_df = pd.read_html(StringIO(r.text))[2]
@@ -50,7 +52,8 @@ def sunrise_daily(date: str = "20200428", city: str = "北京") -> pd.DataFrame:
         year = date[:4]
         month = date[4:6]
         url = f"https://www.timeanddate.com/sun/china/{pypinyin.slug(city, separator='')}?month={month}&year={year}"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         table = pd.read_html(StringIO(r.text), header=2)[1]
         month_df = table.iloc[:-1, ]
         day_df = month_df[month_df.iloc[:, 0].astype(str).str.zfill(2) == date[6:]].copy()
@@ -78,7 +81,8 @@ def sunrise_monthly(date: str = "20190801", city: str = "北京") -> pd.DataFram
         year = date[:4]
         month = date[4:6]
         url = f"https://www.timeanddate.com/sun/china/{pypinyin.slug(city, separator='')}?month={month}&year={year}"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         table = pd.read_html(StringIO(r.text), header=2)[1]
         month_df = table.iloc[:-1, ].copy()
         month_df.index = [date[:-2]] * len(month_df)

--- a/akshare/article/epu_index.py
+++ b/akshare/article/epu_index.py
@@ -6,6 +6,9 @@ Desc: 经济政策不确定性指数
 https://www.policyuncertainty.com/index.html
 """
 import pandas as pd
+import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 
 
 def article_epu_index(symbol: str = "China") -> pd.DataFrame:
@@ -26,10 +29,11 @@ def article_epu_index(symbol: str = "China") -> pd.DataFrame:
         symbol = "US"
     if symbol == "Hong Kong":
         symbol = "HK"
-        epu_df = pd.read_excel(
-            io=f"http://www.policyuncertainty.com/media/{symbol}_EPU_Data_Annotated.xlsx",
-            engine="openpyxl"
-        )
+        url = f"http://www.policyuncertainty.com/media/{symbol}_EPU_Data_Annotated.xlsx"
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        response = requests.get(url, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        epu_df = pd.read_excel(BytesIO(response.content), engine="openpyxl")
         return epu_df
     if symbol in ["Germany", "France", "Italy"]:  # 欧洲
         symbol = "Europe"
@@ -38,19 +42,24 @@ def article_epu_index(symbol: str = "China") -> pd.DataFrame:
     if symbol == "Spain New":
         symbol = "Spain"
     if symbol in ["Ireland", "Chile", "Colombia", "Netherlands", "Singapore", "Sweden"]:
-        epu_df = pd.read_excel(
-            io=f"http://www.policyuncertainty.com/media/{symbol}_Policy_Uncertainty_Data.xlsx",
-            engine="openpyxl"
-        )
+        url = f"http://www.policyuncertainty.com/media/{symbol}_Policy_Uncertainty_Data.xlsx"
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        response = requests.get(url, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        epu_df = pd.read_excel(BytesIO(response.content), engine="openpyxl")
         return epu_df
     if symbol == "Greece":
-        epu_df = pd.read_excel(
-            io=f"http://www.policyuncertainty.com/media/FKT_{symbol}_Policy_Uncertainty_Data.xlsx",
-            engine="openpyxl"
-        )
+        url = f"http://www.policyuncertainty.com/media/FKT_{symbol}_Policy_Uncertainty_Data.xlsx"
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        response = requests.get(url, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        epu_df = pd.read_excel(BytesIO(response.content), engine="openpyxl")
         return epu_df
     url = f"http://www.policyuncertainty.com/media/{symbol}_Policy_Uncertainty_Data.csv"
-    epu_df = pd.read_csv(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    response = requests.get(url, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    epu_df = pd.read_csv(BytesIO(response.content))
     return epu_df
 
 

--- a/akshare/article/ff_factor.py
+++ b/akshare/article/ff_factor.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.article.cons import ff_home_url
 
@@ -20,7 +21,8 @@ def article_ff_crr() -> pd.DataFrame:
     :return: FF多因子模型单一表格
     :rtype: pandas.DataFrame
     """
-    res = requests.get(ff_home_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(ff_home_url, headers=headers, timeout=timeout)
     # first table
     list_index = (
         pd.read_html(StringIO(res.text), header=0, index_col=0)[4].iloc[2, :].index.tolist()

--- a/akshare/article/fred_md.py
+++ b/akshare/article/fred_md.py
@@ -7,6 +7,9 @@ https://research.stlouisfed.org/econ/mccracken/fred-databases/
 FRED-MD and FRED-QD are large macroeconomic databases designed for the empirical analysis of “big data.” The datasets of monthly and quarterly observations mimic the coverage of datasets already used in the literature, but they add three appealing features. They are updated in real-time through the FRED database. They are publicly accessible, facilitating the replication of empirical work. And they relieve the researcher of the task of incorporating data changes and revisions (a task accomplished by the data desk at the Federal Reserve Bank of St. Louis).
 """
 import pandas as pd
+import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import StringIO
 
 
 def fred_md(date: str = "2020-01") -> pd.DataFrame:
@@ -18,7 +21,10 @@ def fred_md(date: str = "2020-01") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://s3.amazonaws.com/files.fred.stlouisfed.org/fred-md/monthly/{date}.csv"
-    temp_df = pd.read_csv(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    response = requests.get(url, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    temp_df = pd.read_csv(StringIO(response.text))
     return temp_df
 
 
@@ -31,7 +37,10 @@ def fred_qd(date: str = "2020-01") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://s3.amazonaws.com/files.fred.stlouisfed.org/fred-md/quarterly/{date}.csv"
-    temp_df = pd.read_csv(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    response = requests.get(url, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    temp_df = pd.read_csv(StringIO(response.text))
     return temp_df
 
 

--- a/akshare/article/risk_rv.py
+++ b/akshare/article/risk_rv.py
@@ -8,6 +8,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import urllib3
 from bs4 import BeautifulSoup
 
@@ -61,7 +62,8 @@ def article_oman_rv(symbol: str = "FTSE", index: str = "rk_th2") -> pd.DataFrame
     | .STOXX50E | EURO STOXX 50                             | January 03, 2000   | November 28, 2019 |
     """
     url = "https://realized.oxford-man.ox.ac.uk/theme/js/visualization-data.js?20191111113154"
-    res = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     soup_text = soup.find("p").get_text()
     data_json = json.loads(soup_text[soup_text.find("{"): soup_text.rfind("};") + 1])
@@ -104,7 +106,8 @@ def article_oman_rv_short(symbol: str = "FTSE") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36",
     }
 
-    res = requests.get(url, headers=headers, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, verify=False, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     soup_text = soup.find("p").get_text()
     data_json = json.loads(soup_text[soup_text.find("{"): soup_text.rfind("}") + 1])
@@ -159,7 +162,8 @@ def article_rlab_rv(symbol: str = "39693") -> pd.DataFrame:
     print("由于服务器在国外, 请稍后, 如果访问失败, 请使用代理工具")
     url = "https://dachxiu.chicagobooth.edu/data.php"
     payload = {"ticker": symbol}
-    res = requests.get(url, params=payload, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, params=payload, verify=False, headers=headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     title_fore = (
         pd.DataFrame(soup.find("p").get_text().split(symbol)).iloc[0, 0].strip()

--- a/akshare/bank/bank_cbirc_2020.py
+++ b/akshare/bank/bank_cbirc_2020.py
@@ -14,6 +14,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 from akshare.bank.cons import cbirc_headers_without_cookie_2020
@@ -40,7 +41,8 @@ def bank_fjcf_total_num(item: str = "分局本级") -> int:
         "pageSize": "18",
         "pageIndex": "1",
     }
-    res = requests.get(main_url, params=params, headers=cbirc_headers)
+    cbirc_headers, timeout = get_headers_and_timeout(locals().get('cbirc_headers', {}), locals().get('timeout', None))
+    res = requests.get(main_url, params=params, headers=cbirc_headers, timeout=timeout)
     return int(res.json()["data"]["total"])
 
 
@@ -67,7 +69,8 @@ def bank_fjcf_total_page(item: str = "分局本级", begin: int = 1) -> int:
         "pageSize": "18",
         "pageIndex": str(begin),
     }
-    res = requests.get(main_url, params=params, headers=cbirc_headers)
+    cbirc_headers, timeout = get_headers_and_timeout(locals().get('cbirc_headers', {}), locals().get('timeout', None))
+    res = requests.get(main_url, params=params, headers=cbirc_headers, timeout=timeout)
     if res.json()["data"]["total"] / 18 > int(res.json()["data"]["total"] / 18):
         total_page = int(res.json()["data"]["total"] / 18) + 1
         return total_page
@@ -101,7 +104,8 @@ def bank_fjcf_page_url(
             "pageSize": "18",
             "pageIndex": str(i_page),
         }
-        res = requests.get(main_url, params=params, headers=cbirc_headers)
+        cbirc_headers, timeout = get_headers_and_timeout(locals().get('cbirc_headers', {}), locals().get('timeout', None))
+        res = requests.get(main_url, params=params, headers=cbirc_headers, timeout=timeout)
         temp_df = pd.concat([temp_df, pd.DataFrame(res.json()["data"]["rows"])])
     return temp_df[
         ["docId", "docSubtitle", "publishDate", "docFileUrl", "docTitle", "generaltype"]
@@ -126,7 +130,8 @@ def bank_fjcf_table_detail(
     big_df = pd.DataFrame()
     for item in id_list:
         url = f"https://www.cbirc.gov.cn/cn/static/data/DocInfo/SelectByDocId/data_docId={item}.json"
-        res = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(url, headers=headers, timeout=timeout)
         try:
             table_list = pd.read_html(StringIO(res.json()["data"]["docClob"]))[0]
             if table_list.shape[1] == 2:

--- a/akshare/bond/bond_cb_sina.py
+++ b/akshare/bond/bond_cb_sina.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def bond_cb_profile_sina(symbol: str = "sz128039") -> pd.DataFrame:
@@ -21,7 +22,8 @@ def bond_cb_profile_sina(symbol: str = "sz128039") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://money.finance.sina.com.cn/bond/info/{symbol}.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df.columns = ["item", "value"]
     return temp_df
@@ -37,7 +39,8 @@ def bond_cb_summary_sina(symbol: str = "sh155255") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://money.finance.sina.com.cn/bond/quotes/{symbol}.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[10]
     part1 = temp_df.iloc[:, 0:2].copy()
     part1.columns = ["item", "value"]

--- a/akshare/bond/bond_cb_ths.py
+++ b/akshare/bond/bond_cb_ths.py
@@ -6,6 +6,7 @@ Desc: 同花顺-数据中心-可转债
 http://data.10jqka.com.cn/ipo/bond/
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -20,7 +21,8 @@ def bond_zh_cov_info_ths() -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["list"])
     temp_df.rename(

--- a/akshare/bond/bond_cbond.py
+++ b/akshare/bond/bond_cbond.py
@@ -6,6 +6,7 @@ Desc: 中国债券信息网-中债指数-中债指数族系-总指数-综合类�
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def bond_new_composite_index_cbond(
@@ -71,7 +72,8 @@ def bond_new_composite_index_cbond(
         "": "",
         "locale": "",
     }
-    r = requests.post(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame.from_dict(
         data_json[f"{indicator_map[indicator]}_{period_map[period]}"],
@@ -144,7 +146,8 @@ def bond_composite_index_cbond(
         "": "",
         "locale": "",
     }
-    r = requests.post(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame.from_dict(
         data_json[f"{indicator_map[indicator]}_{period_map[period]}"],

--- a/akshare/bond/bond_china.py
+++ b/akshare/bond/bond_china.py
@@ -11,6 +11,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.bond.bond_china_money import bond_china_close_return_map
 
@@ -31,7 +32,8 @@ def bond_spot_quote() -> pd.DataFrame:
         "flag": "1",
         "lang": "cn",
     }
-    r = requests.post(url=url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url=url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [
@@ -90,7 +92,8 @@ def bond_spot_deal() -> pd.DataFrame:
         "lang": "cn",
         "bondName": "",
     }
-    r = requests.post(url=url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url=url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [
@@ -161,7 +164,8 @@ def bond_china_yield(
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
     }
-    res = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = res.text.replace("&nbsp", "")
     data_df = pd.read_html(StringIO(data_text), header=0)[1]
     data_df['日期'] = pd.to_datetime(data_df['日期'], errors="coerce").dt.date

--- a/akshare/bond/bond_china_money.py
+++ b/akshare/bond/bond_china_money.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def __bond_register_service() -> requests.Session:
@@ -23,8 +24,10 @@ def __bond_register_service() -> requests.Session:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
 
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     session.get(url="https://www.chinamoney.com.cn/chinese/bkcurvclosedyhis/?bondType=CYCC000&reference=1",
-                headers=headers)
+                headers=headers,
+                timeout=timeout)
     cookies_dict = session.cookies.get_dict()
     cookies_str = '; '.join(f'{k}={v}' for k, v in cookies_dict.items())
     data = {
@@ -49,7 +52,8 @@ def __bond_register_service() -> requests.Session:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest"
     }
-    session.post(url="https://www.chinamoney.com.cn/dqs/rest/cm-u-rbt/apply", data=data, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    session.post(url="https://www.chinamoney.com.cn/dqs/rest/cm-u-rbt/apply", data=data, headers=headers, timeout=timeout)
 
     # 20231127 新增部分 https://github.com/akfamily/akshare/issues/4299
     cookies_dict = session.cookies.get_dict()
@@ -71,7 +75,8 @@ def __bond_register_service() -> requests.Session:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest"
     }
-    session.post(url="https://www.chinamoney.com.cn/lss/rest/cm-s-account/getSessionUser", headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    session.post(url="https://www.chinamoney.com.cn/lss/rest/cm-s-account/getSessionUser", headers=headers, timeout=timeout)
     return session
 
 
@@ -99,11 +104,12 @@ def bond_china_close_return_map() -> pd.DataFrame:
     }
     url = "http://www.chinamoney.com.cn/ags/ms/cm-u-bk-currency/ClsYldCurvCurvGO"
     try:
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_json = r.json()
     except:
         session = __bond_register_service()
-        r = session.get(url, headers=headers)
+        r = session.get(url, headers=headers ,timeout=timeout)
         data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     return temp_df
@@ -145,7 +151,8 @@ def bond_china_close_return(
         "pageNum": "1",
         "pageSize": "15",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     del temp_df["newDateValue"]
@@ -221,7 +228,8 @@ def macro_china_swap_rate(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, data=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [
@@ -313,7 +321,8 @@ def macro_china_bond_public() -> pd.DataFrame:
         "pageSize": "1000",
         "limit": "1",
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/bond/bond_convert.py
+++ b/akshare/bond/bond_convert.py
@@ -9,6 +9,7 @@ Desc: 债券-集思录-可转债
 from io import StringIO
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -21,7 +22,8 @@ def bond_cb_index_jsl() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://www.jisilu.cn/webapi/cb/index_history/"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_dict = demjson.decode(r.text)["data"]
     temp_df = pd.DataFrame(data_dict)
     return temp_df
@@ -82,7 +84,8 @@ def bond_cb_jsl(cookie: str = None) -> pd.DataFrame:
         "bond_ids": "",
         "rp": "50",
     }
-    r = requests.post(url, params=params, json=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame([item["cell"] for item in data_json["rows"]])
     temp_df.rename(
@@ -197,7 +200,8 @@ def bond_cb_redeem_jsl() -> pd.DataFrame:
     payload = {
         "rp": "50",
     }
-    r = requests.post(url, params=params, json=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame([item["cell"] for item in data_json["rows"]])
     temp_df.rename(
@@ -303,7 +307,8 @@ def bond_cb_adj_logs_jsl(symbol: str = "128013") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://www.jisilu.cn/data/cbnew/adj_logs/?bond_id={symbol}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     if "</table>" not in data_text:
         # 1. 该可转债没有转股价调整记录，服务端返回文本 '暂无数据'

--- a/akshare/bond/bond_em.py
+++ b/akshare/bond/bond_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/cjsj/zmgzsyl.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -32,7 +33,8 @@ def bond_zh_us_rate(start_date: str = "19901219") -> pd.DataFrame:
         "pageNum": "1",
         "_": "1615791534490",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -49,7 +51,8 @@ def bond_zh_us_rate(start_date: str = "19901219") -> pd.DataFrame:
             "pageNum": page,
             "_": "1615791534490",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         for col in temp_df.columns:

--- a/akshare/bond/bond_futures.py
+++ b/akshare/bond/bond_futures.py
@@ -7,6 +7,7 @@ http://www.csindex.com.cn/zh-CN/bond-valuation/bond-futures-deliverable-coupons-
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def bond_futures_deliverable_coupons(trade_date: str = "20200923") -> pd.DataFrame:
@@ -35,7 +36,8 @@ def bond_futures_deliverable_coupons(trade_date: str = "20200923") -> pd.DataFra
         'Upgrade-Insecure-Requests': '1',
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36',
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(r.text)[0]
     temp_df['日期'] = temp_df['日期'].astype(str)
     temp_df['银行间代码'] = temp_df['银行间代码'].astype(str)

--- a/akshare/bond/bond_info_cm.py
+++ b/akshare/bond/bond_info_cm.py
@@ -9,6 +9,7 @@ import functools
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -27,7 +28,8 @@ def bond_info_cm_query(symbol: str = "评级等级") -> pd.DataFrame:
         headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
         }
-        r = requests.post(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["enty"])
         temp_df.columns = ["code", "name"]
@@ -44,7 +46,8 @@ def bond_info_cm_query(symbol: str = "评级等级") -> pd.DataFrame:
         headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
         }
-        r = requests.post(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"][f"{symbol_map[symbol]}"])
         if temp_df.shape[1] == 1:
@@ -129,13 +132,15 @@ def bond_info_cm(
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["data"]["pageTotal"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         payload.update({"pageNo": page})
-        r = requests.post(url, data=payload, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, data=payload, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["resultList"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -177,7 +182,8 @@ def bond_info_detail_cm(symbol: str = "淮安农商行CDSD2022021012") -> pd.Dat
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     data_dict = data_json["data"]["bondBaseInfo"]
     if data_dict["creditRateEntyList"]:

--- a/akshare/bond/bond_investing.py
+++ b/akshare/bond/bond_investing.py
@@ -9,6 +9,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.index.cons import short_headers, long_headers
@@ -22,7 +23,9 @@ def _get_global_country_name_url() -> dict:
     :rtype: dict
     """
     url = "https://cn.investing.com/rates-bonds/"
-    res = requests.get(url, headers=short_headers, timeout=30)
+    timeout = 30
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     name_url_option_list = soup.find("select", attrs={"name": "country"}).find_all(
         "option"
@@ -43,7 +46,9 @@ def bond_investing_global_country_name_url(country: str = "中国") -> dict:
     """
     name_url_dict = _get_global_country_name_url()
     url = f"https://cn.investing.com{name_url_dict[country]}"
-    res = requests.get(url, headers=short_headers, timeout=30)
+    timeout = 30
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     url_list = [
         item.find("a")["href"] for item in soup.find_all(attrs={"class": "plusIconTd"})
@@ -85,7 +90,9 @@ def bond_investing_global(
     period_map = {"每日": "Daily", "每周": "Weekly", "每月": "Monthly"}
     name_code_dict = bond_investing_global_country_name_url(country)
     temp_url = f"https://cn.investing.com/{name_code_dict[index_name]}-historical-data"
-    res = requests.get(temp_url, headers=short_headers, timeout=30)
+    timeout = 30
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.get(temp_url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     title = soup.find("h2", attrs={"class": "float_lang_base_1"}).get_text()
     data = soup.find_all(text=re.compile("window.histDataExcessInfo"))[0].strip()
@@ -102,7 +109,9 @@ def bond_investing_global(
         "action": "historical_data",
     }
     url = "https://cn.investing.com/instruments/HistoricalDataAjax"
-    res = requests.post(url, data=payload, headers=long_headers, timeout=60)
+    timeout = 60
+    long_headers, timeout = get_headers_and_timeout(locals().get('long_headers', {}), locals().get('timeout', None))
+    res = requests.post(url, data=payload, headers=long_headers, timeout=timeout)
     df_data = pd.read_html(res.text)[0]
     df_data.columns = [
         "日期",

--- a/akshare/bond/bond_issue_cninfo.py
+++ b/akshare/bond/bond_issue_cninfo.py
@@ -9,6 +9,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -65,7 +66,8 @@ def bond_treasure_issue_cninfo(
         "sdate": "-".join([start_date[:4], start_date[4:6], start_date[6:]]),
         "edate": "-".join([end_date[:4], end_date[4:6], end_date[6:]]),
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.rename(
@@ -157,7 +159,8 @@ def bond_local_government_issue_cninfo(
         "sdate": "-".join([start_date[:4], start_date[4:6], start_date[6:]]),
         "edate": "-".join([end_date[:4], end_date[4:6], end_date[6:]]),
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.rename(
@@ -248,7 +251,8 @@ def bond_corporate_issue_cninfo(
         "sdate": "-".join([start_date[:4], start_date[4:6], start_date[6:]]),
         "edate": "-".join([end_date[:4], end_date[4:6], end_date[6:]]),
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.rename(
@@ -343,7 +347,8 @@ def bond_cov_issue_cninfo(
         "sdate": "-".join([start_date[:4], start_date[4:6], start_date[6:]]),
         "edate": "-".join([end_date[:4], end_date[4:6], end_date[6:]]),
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.rename(
@@ -467,7 +472,8 @@ def bond_cov_stock_issue_cninfo() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.rename(

--- a/akshare/bond/bond_nafmii.py
+++ b/akshare/bond/bond_nafmii.py
@@ -8,6 +8,7 @@ Desc:中国银行间市场交易商协会(https://www.nafmii.org.cn/)
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def bond_debt_nafmii(page: str = "1") -> pd.DataFrame:
@@ -32,7 +33,8 @@ def bond_debt_nafmii(page: str = "1") -> pd.DataFrame:
         "rows": 50,
     }
     payload.update({"page": page})
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()  # 数据类型为 json 格式
     temp_df = pd.DataFrame(data_json["rows"])
     temp_df.rename(

--- a/akshare/bond/bond_summary.py
+++ b/akshare/bond/bond_summary.py
@@ -9,6 +9,7 @@ from io import BytesIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def bond_cash_summary_sse(date: str = '20210111') -> pd.DataFrame:
@@ -30,7 +31,8 @@ def bond_cash_summary_sse(date: str = '20210111') -> pd.DataFrame:
         'sqlId': 'COMMON_SSEBOND_SCSJ_SCTJ_SCGL_ZQXQSCGL_CX_L',
         'TRADE_DATE': f'{date[:4]}-{date[4:6]}-{date[6:]}',
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_excel(BytesIO(r.content), engine="xlrd")
     temp_df.columns = [
         '债券现货',
@@ -65,7 +67,8 @@ def bond_deal_summary_sse(date: str = '20210104') -> pd.DataFrame:
         'sqlId': 'COMMON_SSEBOND_SCSJ_SCTJ_SCGL_ZQCJGL_CX_L',
         'TRADE_DATE': f'{date[:4]}-{date[4:6]}-{date[6:]}',
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_excel(BytesIO(r.content))
     temp_df.columns = [
         '债券类型',

--- a/akshare/bond/bond_zh_cov.py
+++ b/akshare/bond/bond_zh_cov.py
@@ -11,6 +11,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.bond.cons import (
@@ -34,7 +35,8 @@ def _get_zh_bond_hs_cov_page_count() -> int:
     params = {
         "node": "hskzz_z",
     }
-    r = requests.get(zh_sina_bond_hs_cov_count_url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(zh_sina_bond_hs_cov_count_url, params=params, headers=headers, timeout=timeout)
     page_count = int(re.findall(re.compile(r"\d+"), r.text)[0]) / 80
     if isinstance(page_count, int):
         return page_count
@@ -55,7 +57,8 @@ def bond_zh_hs_cov_spot() -> pd.DataFrame:
     tqdm = get_tqdm()
     for page in tqdm(range(1, page_count + 1), leave=False):
         zh_sina_bond_hs_payload_copy.update({"page": page})
-        res = requests.get(zh_sina_bond_hs_cov_url, params=zh_sina_bond_hs_payload_copy)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_bond_hs_cov_url, params=zh_sina_bond_hs_payload_copy, headers=headers, timeout=timeout)
         data_json = demjson.decode(res.text)
         big_df = pd.concat([big_df, pd.DataFrame(data_json)], ignore_index=True)
     return big_df
@@ -70,10 +73,13 @@ def bond_zh_hs_cov_daily(symbol: str = "sh010107") -> pd.DataFrame:
     :return: 指定沪深可转债代码的日 K 线数据
     :rtype: pandas.DataFrame
     """
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         zh_sina_bond_hs_cov_hist_url.format(
             symbol, datetime.datetime.now().strftime("%Y_%m_%d")
-        )
+        ),
+        headers=headers,
+        timeout=timeout
     )
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)
@@ -106,7 +112,8 @@ def _code_id_map() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df["market_id"] = 1
@@ -125,7 +132,8 @@ def _code_id_map() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df_sz = pd.DataFrame(data_json["data"]["diff"])
     temp_df_sz["sz_id"] = 0
@@ -168,7 +176,8 @@ def bond_zh_hs_cov_min(
             "ut": "f057cbcbce2a86e2866ab8877db1d059",
             "ndays": "1",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["trends"]]
@@ -216,7 +225,8 @@ def bond_zh_hs_cov_min(
             "ut": "7eea3edcaed734bea9cbfc24409ed989",
             "forcect": "1",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]
@@ -287,7 +297,8 @@ def bond_zh_hs_cov_pre_min(symbol: str = "sh113570") -> pd.DataFrame:
         "secid": f"{market_type[symbol[:2]]}.{symbol[2:]}",
         "_": "1623766962675",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["trends"]])
     temp_df.columns = [
@@ -336,14 +347,16 @@ def bond_zh_cov() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -490,7 +503,8 @@ def bond_cov_comparison() -> pd.DataFrame:
         "f235,f236,f237,f238,f239,f240,f241,f242,f26,f243",
         "_": "1590386857527",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     json_data = demjson.decode(text_data)
     temp_df = pd.DataFrame(json_data["data"]["diff"])
@@ -594,7 +608,8 @@ def bond_zh_cov_info(
                 "f240~10~SECURITY_CODE~REDEEM_TRIG_PRICE,f23~01~CONVERT_STOCK_CODE~PBV_RATIO",
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame.from_dict(data_json["result"]["data"])
         return temp_df
@@ -605,7 +620,8 @@ def bond_zh_cov_info(
                 "quoteColumns": "",
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame.from_dict(data_json["result"]["data"])
         return temp_df
@@ -618,7 +634,8 @@ def bond_zh_cov_info(
                 "sortTypes": "1",
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame.from_dict(data_json["result"]["data"])
         return temp_df
@@ -629,7 +646,8 @@ def bond_zh_cov_info(
                 "quoteColumns": "",
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame.from_dict(data_json["result"]["data"])
         return temp_df
@@ -655,7 +673,8 @@ def bond_zh_cov_value_analysis(symbol: str = "113527") -> pd.DataFrame:
         "ps": "8000",
         "_": "1648629088839",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [

--- a/akshare/bond/bond_zh_sina.py
+++ b/akshare/bond/bond_zh_sina.py
@@ -10,6 +10,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.bond.cons import (
@@ -33,7 +34,8 @@ def get_zh_bond_hs_page_count() -> int:
     params = {
         "node": "hs_z",
     }
-    res = requests.get(zh_sina_bond_hs_count_url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(zh_sina_bond_hs_count_url, params=params, headers=headers, timeout=timeout)
     page_count = int(re.findall(re.compile(r"\d+"), res.text)[0]) / 80
     if isinstance(page_count, int):
         return page_count
@@ -54,7 +56,8 @@ def bond_zh_hs_spot() -> pd.DataFrame:
     big_df = pd.DataFrame()
     for page in tqdm(range(1, page_count + 1), leave=False):
         zh_sina_bond_hs_payload_copy.update({"page": page})
-        r = requests.get(zh_sina_bond_hs_url, params=zh_sina_bond_hs_payload_copy)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(zh_sina_bond_hs_url, params=zh_sina_bond_hs_payload_copy, headers=headers, timeout=timeout)
         data_json = demjson.decode(r.text)
         temp_df = pd.DataFrame(data_json)
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -114,10 +117,13 @@ def bond_zh_hs_daily(symbol: str = "sh010107") -> pd.DataFrame:
     :return: 指定沪深债券代码的日 K 线数据
     :rtype: pandas.DataFrame
     """
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         zh_sina_bond_hs_hist_url.format(
             symbol, datetime.datetime.now().strftime("%Y_%m_%d")
-        )
+        ),
+        headers=headers,
+        timeout=timeout
     )
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)

--- a/akshare/cost/cost_living.py
+++ b/akshare/cost/cost_living.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -19,7 +20,8 @@ def _get_region() -> dict:
     :rtype: dict
     """
     url = "https://www.expatistan.com/cost-of-living/index"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     half_url_list = [
         item["href"]
@@ -54,7 +56,8 @@ def cost_living(symbol: str = "world") -> pd.DataFrame:
         "world": "/cost-of-living/index",
     }
     url = f"https://www.expatistan.com{name_url_map[symbol]}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df.columns = ["rank", "city", "index"]
     return temp_df

--- a/akshare/crypto/crypto_bitcoin_cme.py
+++ b/akshare/crypto/crypto_bitcoin_cme.py
@@ -7,6 +7,7 @@ https://datacenter.jin10.com/reportType/dc_cme_btc_report
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def crypto_bitcoin_cme(date: str = "20230830") -> pd.DataFrame:
@@ -41,7 +42,8 @@ def crypto_bitcoin_cme(date: str = "20230830") -> pd.DataFrame:
         "x-csrf-token": "",
         "x-version": "1.0.0",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(
         [item for item in data_json["data"]["values"]],

--- a/akshare/crypto/crypto_hist_investing.py
+++ b/akshare/crypto/crypto_hist_investing.py
@@ -11,6 +11,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 from akshare.datasets import get_crypto_info_csv
@@ -101,7 +102,8 @@ def crypto_name_url_table(symbol: str = "web") -> pd.DataFrame:
             'search[regex]': 'false',
             'currencyId': '12',
         }
-        r = requests.post(url, data=payload, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, data=payload, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = math.ceil(int(data_json['recordsTotal']) / 100)
         big_df = pd.DataFrame()
@@ -110,7 +112,8 @@ def crypto_name_url_table(symbol: str = "web") -> pd.DataFrame:
                 "start": (page-1)*100,
                 'length': 100
             })
-            r = requests.post(url, data=payload, headers=headers)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.post(url, data=payload, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json['data'])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -172,7 +175,8 @@ def crypto_hist(
         "sort_ord": "DESC",
         "action": "historical_data",
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
 
     temp_df = pd.read_html(r.text)[0]
     df_data = temp_df.copy()

--- a/akshare/crypto/crypto_hold.py
+++ b/akshare/crypto/crypto_hold.py
@@ -7,6 +7,7 @@ https://datacenter.jin10.com/dc_report?name=bitcoint
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def crypto_bitcoin_hold_report():
@@ -21,7 +22,8 @@ def crypto_bitcoin_hold_report():
         "X-App-Id": "lnFP5lxse24wPgtY",
         "X-Version": "1.0.0",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
 
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["values"])

--- a/akshare/currency/currency.py
+++ b/akshare/currency/currency.py
@@ -8,6 +8,7 @@ https://currencyscoop.com/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def currency_latest(
@@ -27,7 +28,8 @@ def currency_latest(
     """
     params = {"base": base, "symbols": symbols, "api_key": api_key}
     url = "https://api.currencyscoop.com/v1/latest"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.DataFrame.from_dict(r.json()["response"])
     temp_df["date"] = pd.to_datetime(temp_df["date"])
     temp_df.reset_index(inplace=True)
@@ -54,7 +56,8 @@ def currency_history(
     """
     params = {"base": base, "date": date, "symbols": symbols, "api_key": api_key}
     url = "https://api.currencyscoop.com/v1/historical"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.DataFrame.from_dict(r.json()["response"])
     temp_df["date"] = pd.to_datetime(temp_df["date"]).dt.date
     temp_df.reset_index(inplace=True)
@@ -94,7 +97,8 @@ def currency_time_series(
         "symbols": symbols,
     }
     url = "https://api.currencyscoop.com/v1/timeseries"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.DataFrame.from_dict(r.json()["response"])
     temp_df = temp_df.T
     temp_df.reset_index(inplace=True)
@@ -116,7 +120,8 @@ def currency_currencies(c_type: str = "fiat", api_key: str = "") -> pd.DataFrame
     """
     params = {"type": c_type, "api_key": api_key}
     url = "https://api.currencyscoop.com/v1/currencies"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["response"])
     return temp_df
@@ -149,7 +154,8 @@ def currency_convert(
         "api_key": api_key,
     }
     url = "https://api.currencyscoop.com/v1/convert"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_se = pd.Series(r.json()["response"])
     temp_se["timestamp"] = pd.to_datetime(temp_se["timestamp"], unit="s")
     temp_df = temp_se.to_frame()

--- a/akshare/currency/currency_china_bank_sina.py
+++ b/akshare/currency/currency_china_bank_sina.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -35,7 +36,8 @@ def _currency_boc_sina_map(
         "money_code": "EUR",
         "type": "0",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     r.encoding = "gbk"
     soup = BeautifulSoup(r.text, "lxml")
     data_dict = dict(
@@ -78,7 +80,8 @@ def currency_boc_sina(
         "page": "1",
         "call_type": "ajax",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     soup.find(attrs={"id": "money_code"})
     page_element_list = soup.find_all("a", attrs={"class": "page"})
@@ -86,7 +89,8 @@ def currency_boc_sina(
     big_df = pd.DataFrame()
     for page in tqdm(range(1, page_num + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), header=0)[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [

--- a/akshare/economic/macro_australia.py
+++ b/akshare/economic/macro_australia.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/cjsj/foreign_5_0.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -35,7 +36,8 @@ def macro_australia_retail_rate_monthly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -86,7 +88,8 @@ def macro_australia_trade() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -136,7 +139,8 @@ def macro_australia_unemployment_rate() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -186,7 +190,8 @@ def macro_australia_ppi_quarterly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -236,7 +241,8 @@ def macro_australia_cpi_quarterly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -286,7 +292,8 @@ def macro_australia_cpi_yearly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -336,7 +343,8 @@ def macro_australia_bank_rate() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [

--- a/akshare/economic/macro_bank.py
+++ b/akshare/economic/macro_bank.py
@@ -22,6 +22,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 # 金十数据中心-经济指标-央行利率-主要央行利率-美联储利率决议报告
@@ -58,7 +59,8 @@ def macro_bank_usa_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -134,7 +136,8 @@ def macro_bank_euro_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -210,7 +213,8 @@ def macro_bank_newzealand_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -286,7 +290,8 @@ def macro_bank_switzerland_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -362,7 +367,8 @@ def macro_bank_english_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -438,7 +444,8 @@ def macro_bank_australia_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -514,7 +521,8 @@ def macro_bank_japan_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -590,7 +598,8 @@ def macro_bank_russia_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -666,7 +675,8 @@ def macro_bank_india_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -742,7 +752,8 @@ def macro_bank_brazil_interest_rate() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break

--- a/akshare/economic/macro_canada.py
+++ b/akshare/economic/macro_canada.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/cjsj/foreign_5_0.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 # 新屋开工
@@ -33,7 +34,8 @@ def macro_canada_new_house_rate() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -83,7 +85,8 @@ def macro_canada_unemployment_rate() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -133,7 +136,8 @@ def macro_canada_trade() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -183,7 +187,8 @@ def macro_canada_retail_rate_monthly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -233,7 +238,8 @@ def macro_canada_bank_rate() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -283,7 +289,8 @@ def macro_canada_core_cpi_yearly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -333,7 +340,8 @@ def macro_canada_core_cpi_monthly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -383,7 +391,8 @@ def macro_canada_cpi_yearly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -433,7 +442,8 @@ def macro_canada_cpi_monthly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -483,7 +493,8 @@ def macro_canada_gdp_monthly() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [

--- a/akshare/economic/macro_china.py
+++ b/akshare/economic/macro_china.py
@@ -12,6 +12,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 from akshare.economic.cons import (
@@ -41,7 +42,8 @@ def __macro_china_base_func(symbol: str, params: dict) -> pd.DataFrame:
     params = params
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -105,7 +107,8 @@ def macro_china_qyspjg() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(
@@ -199,7 +202,8 @@ def macro_china_fdi() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 
@@ -239,7 +243,8 @@ def macro_china_shrzgm() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://data.mofcom.gov.cn/datamofcom/front/gnmy/shrzgmQuery"
-    r = requests.post(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
     temp_df.columns = [
@@ -307,7 +312,8 @@ def macro_china_urban_unemployment() -> pd.DataFrame:
         "k1": "1691326382042",
         "h": "1",
     }
-    r = requests.get(url, params=params, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, verify=False, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     data_json = r.json()
     value_list = [item["data"]["data"] for item in data_json["returndata"]["datanodes"]]
@@ -614,8 +620,9 @@ def macro_china_shibor_all() -> pd.DataFrame:
 
     t = time.time()
     params = {"_": t}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/il_1.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/il_1.json", params=params, headers=headers, timeout=timeout
     )
     json_data = res.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -660,8 +667,9 @@ def macro_china_hk_market_info() -> pd.DataFrame:
 
     t = time.time()
     params = {"_": t}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/il_2.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/il_2.json", params=params, headers=headers, timeout=timeout
     )
     json_data = res.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -701,10 +709,13 @@ def macro_china_daily_energy() -> pd.DataFrame:
     :return: pandas.DataFrame
     """
     t = time.time()
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
         JS_CHINA_ENERGY_DAILY_URL.format(
             str(int(round(t * 1000))), str(int(round(t * 1000)) + 90)
-        )
+        ),
+        headers=headers,
+        timeout=timeout,
     )
     json_data = json.loads(res.text[res.text.find("{") : res.text.rfind("}") + 1])
     date_list = [item["date"] for item in json_data["list"]]
@@ -733,9 +744,12 @@ def macro_china_rmb() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": t}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
         "https://cdn.jin10.com/data_center/reports/exchange_rate.json",
         params=params,
+        headers=headers,
+        timeout=timeout
     )
     json_data = res.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -840,8 +854,9 @@ def macro_china_market_margin_sz() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": t}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/fs_2.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/fs_2.json", params=params, headers=headers, timeout=timeout
     )
     json_data = res.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -872,7 +887,8 @@ def macro_china_market_margin_sh() -> pd.DataFrame:
     url = "https://cdn.jin10.com/data_center/reports/fs_1.json"
     t = time.time()
     params = {"_": t}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["values"]).T
     temp_df.reset_index(inplace=True)
@@ -905,8 +921,9 @@ def macro_china_au_report() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": t}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/sge.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/sge.json", params=params, headers=headers, timeout=timeout
     )
     json_data = res.json()
     big_df = pd.DataFrame()
@@ -977,13 +994,15 @@ def macro_china_lpr() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1689835278471",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -1029,7 +1048,8 @@ def macro_china_new_house_price(
         "pageNum": "1",
         "_": "1669352163467",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -1100,7 +1120,8 @@ def macro_china_enterprise_boom_index() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669352163467",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -1168,7 +1189,8 @@ def macro_china_national_tax_receipts() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669352163467",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 
@@ -1201,7 +1223,8 @@ def macro_china_bank_financing() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -1246,7 +1269,8 @@ def macro_china_insurance_income() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -1291,7 +1315,8 @@ def macro_china_mobile_number() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.drop_duplicates(inplace=True)
@@ -1337,13 +1362,15 @@ def macro_china_vegetable_basket() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1390,13 +1417,15 @@ def macro_china_agricultural_product() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1443,13 +1472,15 @@ def macro_china_agricultural_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1496,13 +1527,15 @@ def macro_china_energy_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1549,13 +1582,15 @@ def macro_china_commodity_price_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1602,13 +1637,15 @@ def macro_global_sox_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1655,13 +1692,15 @@ def macro_china_yw_electronic_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1712,13 +1751,15 @@ def macro_china_construction_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -1765,13 +1806,15 @@ def macro_china_construction_price_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1818,13 +1861,15 @@ def macro_china_lpi_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1871,13 +1916,15 @@ def macro_china_bdti_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1924,13 +1971,15 @@ def macro_china_bsi_index() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1978,13 +2027,15 @@ def _em_macro_1(em_id) -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -2079,7 +2130,8 @@ def macro_china_new_financial_credit() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 
@@ -2132,7 +2184,8 @@ def macro_china_fx_gold() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1660718498421",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -2196,7 +2249,8 @@ def macro_china_stock_market_cap() -> pd.DataFrame:
         "client": "WEB",
         "_": "1660718498421",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -2282,7 +2336,8 @@ def macro_china_money_supply() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -2367,7 +2422,8 @@ def macro_china_cpi() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -2442,7 +2498,8 @@ def macro_china_gdp() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -2519,7 +2576,8 @@ def macro_china_ppi() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -2565,7 +2623,8 @@ def macro_china_pmi() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -2618,7 +2677,8 @@ def macro_china_gdzctz() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 
@@ -2670,7 +2730,8 @@ def macro_china_hgjck() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(
@@ -2760,7 +2821,8 @@ def macro_china_czsr() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 
@@ -2814,7 +2876,8 @@ def macro_china_whxd() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 
@@ -2864,7 +2927,8 @@ def macro_china_wbck() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 
@@ -2915,7 +2979,8 @@ def macro_china_xfzxx() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 
@@ -2999,7 +3064,8 @@ def macro_china_gyzjz() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1691676211803",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -3045,7 +3111,8 @@ def macro_china_reserve_requirement_ratio() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -3132,7 +3199,8 @@ def macro_china_consumer_goods_retail() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1660718498421",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -3178,14 +3246,16 @@ def macro_china_society_electricity() -> pd.DataFrame:
         "condition": "",
         "_": "1601557771972",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in range(1, page_num):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3232,14 +3302,16 @@ def macro_china_society_traffic_volume() -> pd.DataFrame:
         "condition": "",
         "_": "1601557771972",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"]["非累计"])
     for i in tqdm(range(1, page_num), leave=False):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"]["非累计"])
@@ -3290,14 +3362,16 @@ def macro_china_postal_telecommunicational() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"]["非累计"])
     for i in tqdm(range(1, page_num)):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"]["非累计"])
@@ -3324,14 +3398,16 @@ def macro_china_international_tourism_fx() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in tqdm(range(1, page_num)):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3358,14 +3434,16 @@ def macro_china_passenger_load_factor() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in tqdm(range(1, page_num)):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3392,14 +3470,16 @@ def _macro_china_freight_index() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in tqdm(range(1, page_num)):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3423,7 +3503,8 @@ def macro_china_freight_index() -> pd.DataFrame:
         "num": 5000,
         "condition": "",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     columns_list = r.content.decode("gbk").split("\n")[2].split(", ")
     columns_list = [item.strip() for item in columns_list]
     content_list = r.content.decode("gbk").split("\n")[3:]
@@ -3469,14 +3550,16 @@ def macro_china_central_bank_balance() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in tqdm(range(1, page_num)):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3503,14 +3586,16 @@ def macro_china_insurance() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in tqdm(range(1, page_num)):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3537,14 +3622,16 @@ def macro_china_supply_of_money() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in tqdm(range(1, page_num)):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3571,14 +3658,16 @@ def macro_china_foreign_exchange_gold() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in tqdm(range(1, page_num), leave=False):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3606,14 +3695,16 @@ def macro_china_retail_price_index() -> pd.DataFrame:
         "condition": "",
         "_": "1601624495046",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -3])
     page_num = math.ceil(int(data_json["count"]) / 31)
     big_df = pd.DataFrame(data_json["data"])
     for i in tqdm(range(1, page_num), leave=False):
         params.update({"from": i * 31})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -3])
         temp_df = pd.DataFrame(data_json["data"])
@@ -3648,13 +3739,15 @@ def macro_china_real_estate() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/economic/macro_china_hk.py
+++ b/akshare/economic/macro_china_hk.py
@@ -8,6 +8,7 @@ https://data.eastmoney.com/cjsj/foreign_8_0.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def macro_china_hk_core(symbol: str = "EMG00341602") -> pd.DataFrame:
@@ -35,7 +36,8 @@ def macro_china_hk_core(symbol: str = "EMG00341602") -> pd.DataFrame:
         "pageNum": "1",
         "_": "1667639896816",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(

--- a/akshare/economic/macro_china_nbs.py
+++ b/akshare/economic/macro_china_nbs.py
@@ -13,6 +13,7 @@ import jsonpath as jp
 import numpy as np
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
 
@@ -30,7 +31,8 @@ def _get_nbs_tree(idcode: str, dbcode: str) -> List[Dict]:
     """
     url = "https://data.stats.gov.cn/easyquery.htm"
     params = {"id": idcode, "dbcode": dbcode, "wdcode": "zb", "m": "getTree"}
-    r = requests.post(url, params=params, verify=False, allow_redirects=True)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, verify=False, allow_redirects=True, headers=headers, timeout=timeout)
     data_json = r.json()
     return data_json
 
@@ -53,7 +55,8 @@ def _get_nbs_wds_tree(idcode: str, dbcode: str, rowcode: str) -> List[Dict]:
         "wds": '[{"wdcode":"zb","valuecode":"%s"}]' % idcode,
         "k1": str(time.time_ns())[:13],
     }
-    r = requests.post(url, params=params, verify=False, allow_redirects=True)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, verify=False, allow_redirects=True, headers=headers, timeout=timeout)
     data_json = r.json()["returndata"][0]["nodes"]
     return data_json
 
@@ -111,7 +114,8 @@ def macro_china_nbs_nation(
         '{"wdcode":"sj","valuecode":"%s"}]' % (indicator_id, period),
         "k1": str(time.time_ns())[:13],
     }
-    r = requests.get(url, params=params, verify=False, allow_redirects=True)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, verify=False, allow_redirects=True, headers=headers, timeout=timeout)
     data_json = r.json()
 
     # 整理为dataframe
@@ -224,7 +228,8 @@ def macro_china_nbs_region(
         "dfwds": dfwds,
         "k1": str(time.time_ns())[:13],
     }
-    r = requests.get(url, params=params, verify=False, allow_redirects=True)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, verify=False, allow_redirects=True, headers=headers, timeout=timeout)
     data_json = r.json()
 
     # 整理为dataframe

--- a/akshare/economic/macro_constitute.py
+++ b/akshare/economic/macro_constitute.py
@@ -11,6 +11,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -38,7 +39,8 @@ def macro_cons_gold() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -103,7 +105,8 @@ def macro_cons_silver() -> pd.DataFrame:
     }
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -172,18 +175,22 @@ def macro_cons_opec_month() -> pd.DataFrame:
         "x-csrf-token": "",
         "x-version": "1.0.0",
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
         url=f"https://datacenter-api.jin10.com/reports/dates?category=opec&_={str(int(round(t * 1000)))}",
         headers=headers,
+        timeout=timeout
     )  # 日期序列
     all_date_list = res.json()["data"]
     bar = tqdm(reversed(all_date_list))
     for item in bar:
         bar.set_description(f"Please wait for a moment, now downloading {item}'s data")
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         res = requests.get(
             url=f"https://datacenter-api.jin10.com/reports/list?"
             f"category=opec&date={item}&_={str(int(round(t * 1000)))}",
             headers=headers,
+            timeout=timeout
         )
         temp_df = pd.DataFrame(
             res.json()["data"]["values"],

--- a/akshare/economic/macro_euro.py
+++ b/akshare/economic/macro_euro.py
@@ -15,6 +15,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -38,7 +39,8 @@ def macro_euro_gdp_yoy() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -57,7 +59,8 @@ def macro_euro_gdp_yoy() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -95,7 +98,8 @@ def macro_euro_cpi_mom() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -114,7 +118,8 @@ def macro_euro_cpi_mom() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -150,7 +155,8 @@ def macro_euro_cpi_yoy() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -169,7 +175,8 @@ def macro_euro_cpi_yoy() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -204,7 +211,8 @@ def macro_euro_ppi_mom() -> pd.DataFrame:
         "x-csrf-token": "x-csrf-token",
         "x-version": "1.0.0",
     }
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -223,7 +231,8 @@ def macro_euro_ppi_mom() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -259,7 +268,8 @@ def macro_euro_retail_sales_mom() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -278,7 +288,8 @@ def macro_euro_retail_sales_mom() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -314,7 +325,8 @@ def macro_euro_employment_change_qoq() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -333,7 +345,8 @@ def macro_euro_employment_change_qoq() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -369,7 +382,8 @@ def macro_euro_unemployment_rate_mom() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -388,7 +402,8 @@ def macro_euro_unemployment_rate_mom() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -424,7 +439,8 @@ def macro_euro_trade_balance() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -443,7 +459,8 @@ def macro_euro_trade_balance() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -479,7 +496,8 @@ def macro_euro_current_account_mom() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -498,7 +516,8 @@ def macro_euro_current_account_mom() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -534,7 +553,8 @@ def macro_euro_industrial_production_mom() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -553,7 +573,8 @@ def macro_euro_industrial_production_mom() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -589,7 +610,8 @@ def macro_euro_manufacturing_pmi() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -608,7 +630,8 @@ def macro_euro_manufacturing_pmi() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -644,7 +667,8 @@ def macro_euro_services_pmi() -> pd.DataFrame:
         "x-version": "1.0.0",
     }
 
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -663,7 +687,8 @@ def macro_euro_services_pmi() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -698,7 +723,8 @@ def macro_euro_zew_economic_sentiment() -> pd.DataFrame:
         "x-csrf-token": "x-csrf-token",
         "x-version": "1.0.0",
     }
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -717,7 +743,8 @@ def macro_euro_zew_economic_sentiment() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -752,7 +779,8 @@ def macro_euro_sentix_investor_confidence() -> pd.DataFrame:
         "x-csrf-token": "x-csrf-token",
         "x-version": "1.0.0",
     }
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     date_list = data_json["data"]
     date_point_list = [item for num, item in enumerate(date_list) if num % 20 == 0]
@@ -771,7 +799,8 @@ def macro_euro_sentix_investor_confidence() -> pd.DataFrame:
             "x-csrf-token": "x-csrf-token",
             "x-version": "1.0.0",
         }
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             data_json["data"]["values"],
@@ -799,8 +828,9 @@ def macro_euro_lme_holding() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": str(int(round(t * 1000)))}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/lme_position.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/lme_position.json", params=params, headers=headers, timeout=timeout
     )
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -830,8 +860,9 @@ def macro_euro_lme_stock() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": str(int(round(t * 1000)))}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/lme_stock.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/lme_stock.json", params=params, headers=headers, timeout=timeout
     )
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["values"]).T

--- a/akshare/economic/macro_germany.py
+++ b/akshare/economic/macro_germany.py
@@ -6,6 +6,7 @@ Desc: 东方财富-德国-经济数据
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def macro_germany_core(symbol: str = "EMG00179154") -> pd.DataFrame:
@@ -33,7 +34,8 @@ def macro_germany_core(symbol: str = "EMG00179154") -> pd.DataFrame:
         "pageNum": "1",
         "_": "1667639896816",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(

--- a/akshare/economic/macro_japan.py
+++ b/akshare/economic/macro_japan.py
@@ -8,6 +8,7 @@ https://data.eastmoney.com/cjsj/foreign_3_0.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def macro_japan_core(symbol: str = "EMG00341602") -> pd.DataFrame:
@@ -35,7 +36,8 @@ def macro_japan_core(symbol: str = "EMG00341602") -> pd.DataFrame:
         "pageNum": "1",
         "_": "1667639896816",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(

--- a/akshare/economic/macro_other.py
+++ b/akshare/economic/macro_other.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def crypto_js_spot() -> pd.DataFrame:
@@ -29,7 +30,8 @@ def crypto_js_spot() -> pd.DataFrame:
         "x-csrf-token": "x-csrf-token",
         "x-version": "1.0.0",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     data_df = pd.DataFrame(data_json["data"])
     data_df["reported_at"] = pd.to_datetime(data_df["reported_at"])
@@ -97,7 +99,8 @@ def macro_fx_sentiment(
         "x-csrf-token": "",
         "x-version": "1.0.0",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["values"]).T
     temp_df.reset_index(inplace=True)

--- a/akshare/economic/macro_swiss.py
+++ b/akshare/economic/macro_swiss.py
@@ -7,6 +7,7 @@ http://data.eastmoney.com/cjsj/foreign_2_0.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from akshare.utils import demjson
 
 
@@ -35,7 +36,8 @@ def macro_swiss_core(symbol: str = "EMG00341602") -> pd.DataFrame:
         "pageNum": "1",
         "_": "1667639896816",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(

--- a/akshare/economic/macro_uk.py
+++ b/akshare/economic/macro_uk.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/cjsj/foreign_4_0.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def macro_uk_core(symbol: str = "EMG00010348") -> pd.DataFrame:
@@ -34,7 +35,8 @@ def macro_uk_core(symbol: str = "EMG00010348") -> pd.DataFrame:
         "pageNum": "1",
         "_": "1667639896816",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(

--- a/akshare/economic/macro_usa.py
+++ b/akshare/economic/macro_usa.py
@@ -11,6 +11,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def __macro_usa_base_func(symbol: str, params: dict) -> pd.DataFrame:
@@ -34,7 +35,8 @@ def __macro_usa_base_func(symbol: str, params: dict) -> pd.DataFrame:
     params = params
     big_df = pd.DataFrame()
     while True:
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if not data_json["data"]["values"]:
             break
@@ -99,7 +101,8 @@ def macro_usa_phs() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -145,7 +148,8 @@ def macro_usa_cpi_yoy() -> pd.DataFrame:
         "client": "WEB",
         "_": "1689320600161",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     data_list = data_json["result"]["data"]
     temp_df = pd.DataFrame(
@@ -474,8 +478,9 @@ def macro_usa_rig_count() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": t}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/baker.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/baker.json", params=params, headers=headers, timeout=timeout
     )
     temp_df = pd.DataFrame(res.json().get("values")).T
     big_df = pd.DataFrame()
@@ -969,8 +974,9 @@ def macro_usa_crude_inner() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": t}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/usa_oil.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/usa_oil.json", params=params, headers=headers, timeout=timeout
     )
     temp_df = pd.DataFrame(res.json().get("values")).T
     big_df = pd.DataFrame()
@@ -1005,8 +1011,9 @@ def macro_usa_cftc_nc_holding() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": str(int(round(t * 1000)))}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/cftc_4.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/cftc_4.json", params=params, headers=headers, timeout=timeout
     )
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -1034,8 +1041,9 @@ def macro_usa_cftc_c_holding() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": str(int(round(t * 1000)))}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/cftc_2.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/cftc_2.json", params=params, headers=headers, timeout=timeout
     )
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -1063,8 +1071,9 @@ def macro_usa_cftc_merchant_currency_holding() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": str(int(round(t * 1000)))}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/cftc_3.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/cftc_3.json", params=params, headers=headers, timeout=timeout
     )
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -1092,8 +1101,9 @@ def macro_usa_cftc_merchant_goods_holding() -> pd.DataFrame:
     """
     t = time.time()
     params = {"_": str(int(round(t * 1000)))}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/cftc_1.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/cftc_1.json", params=params, headers=headers, timeout=timeout
     )
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["values"]).T
@@ -1121,8 +1131,9 @@ def macro_usa_cme_merchant_goods_holding():
     """
     t = time.time()
     params = {"_": str(int(round(t * 1000)))}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
-        url="https://cdn.jin10.com/data_center/reports/cme_3.json", params=params
+        url="https://cdn.jin10.com/data_center/reports/cme_3.json", params=params, headers=headers, timeout=timeout
     )
     json_data = r.json()
     big_df = pd.DataFrame()

--- a/akshare/economic/marco_cnbs.py
+++ b/akshare/economic/marco_cnbs.py
@@ -6,6 +6,9 @@ Desc: 国家金融与发展实验室-中国宏观杠杆率数据
 http://114.115.232.154:8080/
 """
 import pandas as pd
+import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 
 
 def macro_cnbs() -> pd.DataFrame:
@@ -16,8 +19,11 @@ def macro_cnbs() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://114.115.232.154:8080/handler/download.ashx"
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    res.raise_for_status()
     temp_df = pd.read_excel(
-        url, sheet_name="Data", header=0, skiprows=1, engine="openpyxl"
+        BytesIO(res.content), sheet_name="Data", header=0, skiprows=1, engine="openpyxl"
     )
 
     temp_df["Period"] = pd.to_datetime(temp_df["Period"]).dt.strftime("%Y-%m")

--- a/akshare/energy/energy_carbon.py
+++ b/akshare/energy/energy_carbon.py
@@ -23,6 +23,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -47,7 +48,8 @@ def energy_carbon_domestic(symbol: str = "湖北") -> pd.DataFrame:
         "brand": "TAN",
         "_": "1626773022063",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("(") + 1 : -1])
     temp_df = pd.DataFrame(data_json[symbol])
@@ -85,7 +87,8 @@ def energy_carbon_bj() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://www.bjets.com.cn/article/jyxx/"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     total_page = (
         soup.find("table")
@@ -104,7 +107,8 @@ def energy_carbon_bj() -> pd.DataFrame:
         if i == 1:
             i = ""
         url = f"https://www.bjets.com.cn/article/jyxx/?{i}"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         r.encoding = "utf-8"
         df = pd.read_html(r.text)[0]
         temp_df = pd.concat([temp_df, df], ignore_index=True)
@@ -144,7 +148,8 @@ def energy_carbon_sz() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://www.cerx.cn/dailynewsCN/index.htm"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     page_num = int(
         soup.find(attrs={"class": "pagebar"}).find_all("option")[-1].text
@@ -154,7 +159,8 @@ def energy_carbon_sz() -> pd.DataFrame:
         range(2, page_num + 1), desc="Please wait for a moment", leave=False
     ):
         url = f"http://www.cerx.cn/dailynewsCN/index_{page}.htm"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(r.text, header=0)[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df["交易日期"] = pd.to_datetime(big_df["交易日期"]).dt.date
@@ -179,7 +185,8 @@ def energy_carbon_eu() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://www.cerx.cn/dailynewsOuter/index.htm"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     page_num = int(
         soup.find(attrs={"class": "pagebar"}).find_all("option")[-1].text
@@ -189,7 +196,8 @@ def energy_carbon_eu() -> pd.DataFrame:
         range(2, page_num + 1), desc="Please wait for a moment", leave=False
     ):
         url = f"http://www.cerx.cn/dailynewsOuter/index_{page}.htm"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(r.text, header=0)[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df["交易日期"] = pd.to_datetime(big_df["交易日期"]).dt.date
@@ -214,7 +222,8 @@ def energy_carbon_hb() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://www.hbets.cn/list/13.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     page_string = (
         soup.find("div", attrs={"class": "page"}).find_all("span")[-1].text
@@ -230,7 +239,8 @@ def energy_carbon_hb() -> pd.DataFrame:
     ):
         url = f"http://www.hbets.cn/list/13.html"
         params = {"page": page}
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         soup = BeautifulSoup(r.text, "lxml")
         page_node = [
             item
@@ -286,7 +296,8 @@ def energy_carbon_gz() -> pd.DataFrame:
         "beginTime": "2010-01-01",
         "endTime": "2030-09-12",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(r.text, header=0)[1]
     temp_df.columns = [
         "日期",

--- a/akshare/energy/energy_oil_em.py
+++ b/akshare/energy/energy_oil_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/cjsj/oil_default.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def energy_oil_hist() -> pd.DataFrame:
@@ -31,7 +32,8 @@ def energy_oil_hist() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1652959763351",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = ["调整日期", "汽油价格", "柴油价格", "汽油涨跌", "柴油涨跌"]
@@ -68,7 +70,8 @@ def energy_oil_detail(date: str = "20220517") -> pd.DataFrame:
         "source": "WEB",
         "_": "1652959763351",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"]).iloc[:, 1:]
     temp_df.columns = [

--- a/akshare/event/migration.py
+++ b/akshare/event/migration.py
@@ -8,6 +8,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.event.cons import province_dict, city_dict
 
@@ -44,7 +45,8 @@ def migration_area_baidu(
         "type": indicator,
         "date": date,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text[r.text.find("({") + 1 : r.text.rfind(");")]
     data_json = json.loads(data_text)
     temp_df = pd.DataFrame(data_json["data"]["list"])
@@ -79,7 +81,8 @@ def migration_scale_baidu(
         "id": inner_dict[area],
         "type": indicator,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     json_data = json.loads(r.text[r.text.find("({") + 1 : r.text.rfind(");")])
     temp_df = pd.DataFrame.from_dict(json_data["data"]["list"], orient="index")
     temp_df.index = pd.to_datetime(temp_df.index)

--- a/akshare/fortune/fortune_500.py
+++ b/akshare/fortune/fortune_500.py
@@ -13,6 +13,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -26,7 +27,8 @@ def _fortune_rank_year_url_map() -> dict:
     :rtype: dict
     """
     url = "https://www.fortunechina.com/fortune500/index.htm"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     url_2023 = soup.find(name='meta', attrs={"property": "og:url"})['content'].strip()
     node_list = soup.find_all(name='div', attrs={"class": "swiper-slide"})
@@ -46,7 +48,8 @@ def fortune_rank(year: str = "2015") -> pd.DataFrame:
     """
     year_url_map = _fortune_rank_year_url_map()
     url = year_url_map[year]
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     if int(year) < 2007:
         df = pd.read_html(StringIO(r.text))[0].iloc[1:-1, ]
@@ -57,7 +60,8 @@ def fortune_rank(year: str = "2015") -> pd.DataFrame:
         df.columns = pd.read_html(StringIO(r.text))[0].iloc[0, :].tolist()
         for page in tqdm(range(2, 11), leave=False):
             # page =2
-            r = requests.get(url.rsplit(".", maxsplit=1)[0] + "_" + str(page) + ".htm")
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url.rsplit(".", maxsplit=1, headers=headers, timeout=timeout)[0] + "_" + str(page) + ".htm")
             r.encoding = "utf-8"
             temp_df = pd.read_html(StringIO(r.text))[0].iloc[1:, ]
             temp_df.columns = pd.read_html(StringIO(r.text))[0].iloc[0, :].tolist()
@@ -79,7 +83,8 @@ def fortune_rank_eng(year: str = "2023") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://fortune.com/ranking/global500/{year}/search/"
-    res = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     code = json.loads(soup.find("script", attrs={"type": "application/ld+json"}).string)["identifier"]
     url = f"https://content.fortune.com/wp-json/irving/v1/data/franchise-search-results"
@@ -87,7 +92,8 @@ def fortune_rank_eng(year: str = "2023") -> pd.DataFrame:
         "list_id": code,
         "token": "Zm9ydHVuZTpCcHNyZmtNZCN5SndjWkkhNHFqMndEOTM=",
     }
-    res = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, params=params, headers=headers, timeout=timeout)
     big_df = pd.DataFrame()
     for i in range(len(res.json()[1]["items"][0]['fields'])):
         temp_df = pd.DataFrame([item["fields"][i] for item in res.json()[1]["items"]])

--- a/akshare/fortune/fortune_bloomberg.py
+++ b/akshare/fortune/fortune_bloomberg.py
@@ -7,6 +7,7 @@ https://www.bloomberg.com/billionaires/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -20,7 +21,8 @@ def index_bloomberg_billionaires_hist(year: str = "2021") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://stats.areppim.com/listes/list_billionairesx{year[-2:]}xwor.htm"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     trs = soup.findAll("table")[0].findAll("tr")
     heads = trs[1]
@@ -83,7 +85,8 @@ def index_bloomberg_billionaires() -> pd.DataFrame:
         "referer": "https://www.bloomberg.com/",
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     big_content_list = list()
     soup_node = soup.find(attrs={"class": "table-chart"}).find_all(

--- a/akshare/fortune/fortune_forbes_500.py
+++ b/akshare/fortune/fortune_forbes_500.py
@@ -7,6 +7,7 @@ https://www.forbeschina.com/lists
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -21,7 +22,8 @@ def forbes_rank(symbol: str = "2021福布斯中国创投人100") -> pd.DataFrame
     :rtype: pandas.DataFrame
     """
     url = "https://www.forbeschina.com/lists"
-    r = requests.get(url, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, verify=False, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     need_list = [
         item.find_all("a")
@@ -39,7 +41,8 @@ def forbes_rank(symbol: str = "2021福布斯中国创投人100") -> pd.DataFrame
             ],
         )
     )
-    r = requests.get(name_url_dict[symbol], verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(name_url_dict[symbol], verify=False, headers=headers, timeout=timeout)
     temp_df = pd.read_html(r.text)[0]
     return temp_df
 

--- a/akshare/fortune/fortune_hurun.py
+++ b/akshare/fortune/fortune_hurun.py
@@ -9,6 +9,7 @@ import warnings
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -24,7 +25,8 @@ def hurun_rank(indicator: str = "胡润百富榜", year: str = "2023") -> pd.Dat
     :rtype: pandas.DataFrame
     """
     url = "https://www.hurun.net/zh-CN/Rank/HsRankDetails?pagetype=rich"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     url_list = []
     for item in soup.find_all("ul", attrs={"class": "dropdown-menu"}):
@@ -36,7 +38,8 @@ def hurun_rank(indicator: str = "胡润百富榜", year: str = "2023") -> pd.Dat
             name_list.append(inner_item.text.strip())
 
     name_url_map = dict(zip(name_list, url_list))
-    r = requests.get(name_url_map[indicator])
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(name_url_map[indicator], headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     code_list = [
         item["value"].split("=")[2]
@@ -71,7 +74,8 @@ def hurun_rank(indicator: str = "胡润百富榜", year: str = "2023") -> pd.Dat
                     }
                 )
                 url = "https://www.hurun.net/zh-CN/Rank/HsRankDetailsList"
-                r = requests.get(url, params=params)
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(url, params=params, headers=headers, timeout=timeout)
                 data_json = r.json()
                 temp_df = pd.DataFrame(data_json["rows"])
                 offset = offset + 20
@@ -101,7 +105,8 @@ def hurun_rank(indicator: str = "胡润百富榜", year: str = "2023") -> pd.Dat
         ]
         return big_df
     url = "https://www.hurun.net/zh-CN/Rank/HsRankDetailsList"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["rows"])
     if indicator == "胡润百富榜":

--- a/akshare/fortune/fortune_it_juzi.py
+++ b/akshare/fortune/fortune_it_juzi.py
@@ -8,6 +8,9 @@ https://www.itjuzi.com/chollima
 https://www.itjuzi.com/unicorn
 """
 import pandas as pd
+import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 
 
 def death_company() -> pd.DataFrame:
@@ -18,8 +21,12 @@ def death_company() -> pd.DataFrame:
     :return: 死亡公司名单
     :rtype: pandas.DataFrame
     """
+    url = "https://jfds-1252952517.cos.ap-chengdu.myqcloud.com/akshare/data/data_juzi/juzi.csv"
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
+    r.raise_for_status()
     temp_df = pd.read_csv(
-        "https://jfds-1252952517.cos.ap-chengdu.myqcloud.com/akshare/data/data_juzi/juzi.csv"
+        BytesIO(r.content)
     )
 
     temp_df.reset_index(inplace=True, drop=True)
@@ -43,8 +50,12 @@ def nicorn_company() -> pd.DataFrame:
     :return: 独角兽公司
     :rtype: pandas.DataFrame
     """
+    url = "https://jfds-1252952517.cos.ap-chengdu.myqcloud.com/akshare/data/data_juzi/nicorn_company.csv"
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
+    r.raise_for_status()
     temp_df = pd.read_csv(
-        "https://jfds-1252952517.cos.ap-chengdu.myqcloud.com/akshare/data/data_juzi/nicorn_company.csv",
+        BytesIO(r.content),
         index_col=0,
     )
     temp_df.reset_index(drop=True, inplace=True)
@@ -82,8 +93,12 @@ def maxima_company() -> pd.DataFrame:
     :return: 千里马公司
     :rtype: pandas.DataFrame
     """
+    url = "https://jfds-1252952517.cos.ap-chengdu.myqcloud.com/akshare/data/data_juzi/maxima.csv"
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
+    r.raise_for_status()
     temp_df = pd.read_csv(
-        "https://jfds-1252952517.cos.ap-chengdu.myqcloud.com/akshare/data/data_juzi/maxima.csv",
+        BytesIO(r.content),
         index_col=0,
     )
     temp_df.reset_index(drop=True, inplace=True)

--- a/akshare/fortune/fortune_xincaifu_500.py
+++ b/akshare/fortune/fortune_xincaifu_500.py
@@ -9,6 +9,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def xincaifu_rank(year: str = "2022") -> pd.DataFrame:
@@ -34,7 +35,8 @@ def xincaifu_rank(year: str = "2022") -> pd.DataFrame:
         "from": "jsonp",
         "_": "1604722171732",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = json.loads(data_text[data_text.find("{") : -1])
     temp_df = pd.DataFrame(data_json["data"]["rows"])

--- a/akshare/fund/fund_amac.py
+++ b/akshare/fund/fund_amac.py
@@ -8,6 +8,7 @@ Desc: 中国证券投资基金业协会-信息公示数据
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -23,7 +24,8 @@ def _get_pages(url: str = "", payload: str = "") -> pd.DataFrame:
     中国证券投资基金业协会-信息公示-私募基金管理人公示 页数
     暂时不使用本函数, 直接可以获取所有数据
     """
-    res = requests.post(url=url, json=payload, headers=headers, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.post(url=url, json=payload, headers=headers, verify=False, timeout=timeout)
     res.encoding = "utf-8"
     json_df = res.json()
     return json_df["totalPages"]
@@ -33,7 +35,8 @@ def get_data(url: str = "", payload: str = "") -> pd.DataFrame:
     """
     中国证券投资基金业协会-信息公示-私募基金管理人公示
     """
-    res = requests.post(url=url, json=payload, headers=headers, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.post(url=url, json=payload, headers=headers, verify=False, timeout=timeout)
     res.encoding = "utf-8"
     json_df = res.json()
     return json_df
@@ -54,14 +57,16 @@ def amac_member_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -115,12 +120,14 @@ def amac_person_fund_org_list(symbol: str = "公募基金管理公司") -> pd.Da
         "page": "1",
         "size": "100",
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.post(
         url,
         params=params,
         json={"orgType": symbol_trans, "page": "1"},
         verify=False,
         headers=headers,
+        timeout=timeout
     )
     data_json = r.json()
     total_page = data_json["totalPages"]
@@ -128,12 +135,14 @@ def amac_person_fund_org_list(symbol: str = "公募基金管理公司") -> pd.Da
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         r = requests.post(
             url,
             params=params,
             json={"orgType": symbol_trans, "page": "1"},
             verify=False,
             headers=headers,
+            timeout=timeout
         )
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
@@ -188,7 +197,8 @@ def amac_person_bond_org_list() -> pd.DataFrame:
     http = urllib3.PoolManager(ssl_context=ctx)
 
     url = "https://human.amac.org.cn/web/api/publicityAddress?rand=0.6288001872566391&pageNum=1&pageSize=5000"
-    r = http.request(method="GET", url=url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = http.request(method="GET", url=url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["list"])
     temp_df.reset_index(inplace=True)
@@ -227,14 +237,16 @@ def amac_manager_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -281,14 +293,16 @@ def amac_manager_classify_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -352,14 +366,16 @@ def amac_member_sub_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -406,7 +422,8 @@ def amac_fund_info(start_page: str = "1", end_page: str = "2000") -> pd.DataFram
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = int(data_json["totalPages"])
     if total_page > int(end_page):
@@ -417,7 +434,8 @@ def amac_fund_info(start_page: str = "1", end_page: str = "2000") -> pd.DataFram
     tqdm = get_tqdm()
     for page in tqdm(range(int(start_page) - 1, real_end_page), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -463,14 +481,16 @@ def amac_securities_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -517,14 +537,16 @@ def amac_aoin_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -564,14 +586,16 @@ def amac_fund_sub_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -620,14 +644,16 @@ def amac_fund_account_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -665,14 +691,16 @@ def amac_fund_abs() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -724,14 +752,16 @@ def amac_futures_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -782,14 +812,16 @@ def amac_manager_cancelled_info() -> pd.DataFrame:
         "page": "1",
         "size": "100",
     }
-    r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["totalPages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(0, int(total_page)), leave=False):
         params.update({"page": page})
-        r = requests.post(url, params=params, json={}, verify=False, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, json={}, verify=False, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["content"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)

--- a/akshare/fund/fund_announcement.py
+++ b/akshare/fund/fund_announcement.py
@@ -9,6 +9,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def fund_announcement_personnel_em(symbol: str = "000001") -> pd.DataFrame:
@@ -32,7 +33,8 @@ def fund_announcement_personnel_em(symbol: str = "000001") -> pd.DataFrame:
         "type": "4",
         "_": round(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["Data"])
     temp_df.columns = [

--- a/akshare/fund/fund_aum_em.py
+++ b/akshare/fund/fund_aum_em.py
@@ -8,6 +8,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def fund_aum_em() -> pd.DataFrame:
@@ -21,7 +22,8 @@ def fund_aum_em() -> pd.DataFrame:
     params = {
         'fundType': '0'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     del temp_df['相关链接']
     del temp_df['天相评级']
@@ -47,7 +49,8 @@ def fund_aum_trend_em() -> pd.DataFrame:
     payload = {
         'fundType': '0'
     }
-    r = requests.get(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame()
     temp_df['date'] = data_json['x']
@@ -68,7 +71,8 @@ def fund_aum_hist_em(year: str = "2023") -> pd.DataFrame:
     params = {
         'year': year
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df.columns = ['序号', '基金公司', '总规模', '股票型', '混合型', '债券型', '指数型', 'QDII', '货币型']
     temp_df['总规模'] = pd.to_numeric(temp_df['总规模'], errors="coerce")

--- a/akshare/fund/fund_em.py
+++ b/akshare/fund/fund_em.py
@@ -15,6 +15,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -37,7 +38,8 @@ def fund_purchase_em() -> pd.DataFrame:
         "sort": "fcode,asc",
         "_": "1641528557742",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text.strip("var reData="))
     temp_df = pd.DataFrame(data_json["datas"])
@@ -95,7 +97,8 @@ def fund_name_em() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
     }
     url = "http://fund.eastmoney.com/js/fundcode_search.js"
-    res = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
     text_data = res.text
     data_json = demjson.decode(text_data.strip("var r = ")[:-1])
     temp_df = pd.DataFrame(data_json)
@@ -183,7 +186,8 @@ def fund_info_index_em(
         "Referer": "http://fund.eastmoney.com/",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     data_json = json.loads(data_json["Data"])
     temp_df = pd.DataFrame([item.split("|") for item in data_json["datas"]])
@@ -280,7 +284,8 @@ def fund_open_fund_daily_em() -> pd.DataFrame:
         "atfc": "",
         "onlySale": "0",
     }
-    res = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = res.text
     data_json = demjson.decode(text_data.strip("var db="))
     temp_df = pd.DataFrame(data_json["datas"])
@@ -346,7 +351,8 @@ def fund_open_fund_info_em(
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
 
     # 单位净值走势
@@ -442,7 +448,8 @@ def fund_open_fund_info_em(
             'type': period_map[period],
             '_': '1704012866899'
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['Data'][0]['data'])
         temp_df.columns = ["日期", "累计收益率"]
@@ -518,7 +525,8 @@ def fund_open_fund_info_em(
     # 分红送配详情
     if indicator == "分红送配详情":
         url = f"http://fundf10.eastmoney.com/fhsp_{symbol}.html"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[1]
         if temp_df.iloc[0, 1] == "暂无分红信息!":
             return
@@ -528,7 +536,8 @@ def fund_open_fund_info_em(
     # 拆分详情
     if indicator == "拆分详情":
         url = f"http://fundf10.eastmoney.com/fhsp_{symbol}.html"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[2]
         if temp_df.iloc[0, 1] == "暂无拆分信息!":
             return
@@ -547,7 +556,8 @@ def fund_money_fund_daily_em() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
     }
     url = "http://fund.eastmoney.com/HBJJ_pjsyl.html"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     show_day = pd.read_html(StringIO(r.text))[1].iloc[0, 5:11].tolist()
     temp_df = pd.read_html(StringIO(r.text))[1].iloc[1:, 2:]
@@ -596,7 +606,8 @@ def fund_money_fund_info_em(fund: str = "000009") -> pd.DataFrame:
         "endDate": "",
         "_": round(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     data_json = demjson.decode(text_data[text_data.find("{"): -1])
     temp_df = pd.DataFrame(data_json["Data"]["LSJZList"])
@@ -643,7 +654,8 @@ def fund_financial_fund_daily_em() -> pd.DataFrame:
         "OnlySale": "1",
         "_": "1588248310234",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["Data"]["List"])
     if temp_df.empty:
@@ -715,7 +727,8 @@ def fund_financial_fund_info_em(symbol: str = "000134") -> pd.DataFrame:
         "endDate": "",
         "_": round(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     data_json = demjson.decode(text_data[text_data.find("{"): -1])
     temp_df = pd.DataFrame(data_json["Data"]["LSJZList"])
@@ -766,7 +779,8 @@ def fund_graded_fund_daily_em() -> pd.DataFrame:
         "dt": "1580914040623",
         "atfc": "",
     }
-    res = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = res.text
     data_json = demjson.decode(text_data.strip("var db="))
     temp_df = pd.DataFrame(data_json["datas"])
@@ -834,7 +848,8 @@ def fund_graded_fund_info_em(fund: str = "150232") -> pd.DataFrame:
         "endDate": "",
         "_": round(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     data_json = demjson.decode(text_data[text_data.find("{"): -1])
     temp_df = pd.DataFrame(data_json["Data"]["LSJZList"])
@@ -868,7 +883,8 @@ def fund_etf_fund_daily_em() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
     }
     url = "http://fund.eastmoney.com/cnjy_dwjz.html"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     show_day = pd.read_html(StringIO(r.text))[1].iloc[0, 6:10].tolist()
     temp_df = pd.read_html(StringIO(r.text))[1].iloc[1:, 2:]
@@ -925,7 +941,8 @@ def fund_etf_fund_info_em(
         "endDate": "-".join([end_date[:4], end_date[4:6], end_date[6:]]),
         "_": round(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["Data"]["LSJZList"])
     temp_df.columns = [
@@ -986,7 +1003,8 @@ def fund_value_estimation_em(symbol: str = "全部") -> pd.DataFrame:
         "pageSize": "20000",
         "_": int(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["Data"]["list"])
     value_day = json_data["Data"]["gzrq"]
@@ -1070,7 +1088,8 @@ def fund_hk_fund_hist_em(
             "date2": "",
             "_": "1611131371333",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_one_df = pd.DataFrame(data_json["Data"])
         temp_one_df.columns = [
@@ -1107,7 +1126,8 @@ def fund_hk_fund_hist_em(
             "date2": "",
             "_": "1611131371333",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_one_df = pd.DataFrame(data_json["Data"])
         temp_one_df.columns = [

--- a/akshare/fund/fund_etf_em.py
+++ b/akshare/fund/fund_etf_em.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 @lru_cache()
@@ -35,7 +36,9 @@ def _fund_etf_code_id_map_em() -> dict:
         "fields": "f12,f13",
         "_": "1672806290972",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_dict = dict(zip(temp_df["f12"], temp_df["f13"]))
@@ -71,7 +74,9 @@ def fund_etf_spot_em() -> pd.DataFrame:
         ),
         "_": "1672806290972",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.rename(
@@ -262,17 +267,21 @@ def fund_etf_hist_em(
     try:
         market_id = code_id_dict[symbol]
         params.update({"secid": f"{market_id}.{symbol}"})
-        r = requests.get(url, timeout=15, params=params)
+        timeout = 15
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, timeout=timeout, params=params, headers=headers)
         data_json = r.json()
     except KeyError:
         market_id = 1
         params.update({"secid": f"{market_id}.{symbol}"})
-        r = requests.get(url, timeout=15, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, timeout=15, params=params, headers=headers)
         data_json = r.json()
         if not data_json["data"]:
             market_id = 0
             params.update({"secid": f"{market_id}.{symbol}"})
-            r = requests.get(url, timeout=15, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, timeout=15, params=params, headers=headers)
             data_json = r.json()
     if not (data_json["data"] and data_json["data"]["klines"]):
         return pd.DataFrame()
@@ -355,7 +364,9 @@ def fund_etf_hist_min_em(
             "secid": f"{code_id_dict[symbol]}.{symbol}",
             "_": "1623766962675",
         }
-        r = requests.get(url, timeout=15, params=params)
+        timeout = 15
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, timeout=timeout, params=params, headers=headers)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["trends"]]
@@ -395,7 +406,9 @@ def fund_etf_hist_min_em(
             "end": "20500000",
             "_": "1630930917857",
         }
-        r = requests.get(url, timeout=15, params=params)
+        timeout = 15
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, timeout=timeout, params=params, headers=headers)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]

--- a/akshare/fund/fund_etf_sina.py
+++ b/akshare/fund/fund_etf_sina.py
@@ -7,6 +7,7 @@ http://vip.stock.finance.sina.com.cn/fund_center/index.html#jjhqetf
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.stock.cons import hk_js_decode
@@ -36,7 +37,8 @@ def fund_etf_category_sina(symbol: str = "LOF基金") -> pd.DataFrame:
         "node": fund_map[symbol],
         "[object HTMLDivElement]": "qvvne",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("([") + 1 : -2])
     temp_df = pd.DataFrame(data_json)
@@ -119,7 +121,8 @@ def fund_etf_hist_sina(symbol: str = "sz159996") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://finance.sina.com.cn/realstock/company/{symbol}/hisdata/klc_kl.js"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)
     dict_list = js_code.call(

--- a/akshare/fund/fund_fhsp_em.py
+++ b/akshare/fund/fund_fhsp_em.py
@@ -7,6 +7,7 @@ https://fund.eastmoney.com/data/fundfenhong.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -27,13 +28,15 @@ def fund_fh_em() -> pd.DataFrame:
         "ftype": "",
         "year": "",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     total_page = eval(data_text[data_text.find("=") + 1: data_text.find(";")])[0]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         temp_list = eval(
             data_text[data_text.find("[["): data_text.find(";var jjfh_jjgs")]
@@ -77,13 +80,15 @@ def fund_cf_em() -> pd.DataFrame:
         "ftype": "",
         "year": "",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     total_page = eval(data_text[data_text.find("=") + 1: data_text.find(";")])[0]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         temp_str = data_text[data_text.find("[["): data_text.find(";var jjcf_jjgs")]
         if temp_str:
@@ -125,13 +130,15 @@ def fund_fh_rank_em() -> pd.DataFrame:
         "ftype": "",
         "year": "",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     total_page = eval(data_text[data_text.find("=") + 1: data_text.find(";")])[0]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         temp_list = eval(
             data_text[data_text.find("[["): data_text.find(";var fhph_jjgs")]

--- a/akshare/fund/fund_init_em.py
+++ b/akshare/fund/fund_init_em.py
@@ -7,6 +7,7 @@ https://fund.eastmoney.com/data/xinfound.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -27,7 +28,8 @@ def fund_new_found_em() -> pd.DataFrame:
         "isbuy": "1",
         "v": "0.4069919776543214",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text.strip("var newfunddata="))
     temp_df = pd.DataFrame(data_json["datas"])

--- a/akshare/fund/fund_lof_em.py
+++ b/akshare/fund/fund_lof_em.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 @lru_cache()
@@ -36,7 +37,8 @@ def _fund_lof_code_id_map_em() -> dict:
         "fields": "f12,f13",
         "_": "1672806290972",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_dict = dict(zip(temp_df["f12"], temp_df["f13"]))
@@ -66,7 +68,8 @@ def fund_lof_spot_em() -> pd.DataFrame:
         "f15,f16,f17,f18,f20,f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1672806290972",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.rename(
@@ -159,7 +162,8 @@ def fund_lof_hist_em(
         "end": end_date,
         "_": "1623766962675",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not (data_json["data"] and data_json["data"]["klines"]):
         return pd.DataFrame()
@@ -232,7 +236,8 @@ def fund_lof_hist_min_em(
             "secid": f"{code_id_dict[symbol]}.{symbol}",
             "_": "1623766962675",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["trends"]]
@@ -272,7 +277,8 @@ def fund_lof_hist_min_em(
             "end": "20500000",
             "_": "1630930917857",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]

--- a/akshare/fund/fund_manager.py
+++ b/akshare/fund/fund_manager.py
@@ -7,6 +7,7 @@ https://fund.eastmoney.com/manager/default.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 from akshare.utils import demjson
@@ -30,7 +31,8 @@ def fund_manager_em() -> pd.DataFrame:
         "sc": "abbname",
         "st": "asc",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text.strip("var returnjson= "))
     total_page = data_json["pages"]
@@ -38,7 +40,8 @@ def fund_manager_em() -> pd.DataFrame:
         params.update({
             "pi": page,
         })
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text.strip("var returnjson= "))
         temp_df = pd.DataFrame(data_json["data"])

--- a/akshare/fund/fund_portfolio_em.py
+++ b/akshare/fund/fund_portfolio_em.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.utils import demjson
@@ -36,7 +37,8 @@ def fund_portfolio_hold_em(
         "month": "",
         "rt": "0.913877030254846",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): -1])
     soup = BeautifulSoup(data_json["content"], "lxml")
@@ -109,7 +111,8 @@ def fund_portfolio_bond_hold_em(
         "year": date,
         "rt": "0.913877030254846",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): -1])
     soup = BeautifulSoup(data_json["content"], "lxml")
@@ -175,7 +178,8 @@ def fund_portfolio_industry_allocation_em(
         "callback": "jQuery183006997159478989867_1648016188499",
         "_": "1648016377955",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): -1])
     temp_list = []
@@ -244,7 +248,8 @@ def fund_portfolio_change_em(
         "year": date,
         "rt": "0.913877030254846",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): -1])
     soup = BeautifulSoup(data_json["content"], "lxml")

--- a/akshare/fund/fund_position_lg.py
+++ b/akshare/fund/fund_position_lg.py
@@ -7,6 +7,7 @@ https://legulegu.com/stockdata/fund-position/pos-stock
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock_feature.stock_a_indicator import get_token_lg, get_cookie_csrf
 
@@ -21,10 +22,12 @@ def fund_stock_position_lg() -> pd.DataFrame:
     url = "https://legulegu.com/api/stockdata/fund-position"
     token = get_token_lg()
     params = {"token": token, "type": "pos_stock", "category": "总仓位", "marketId": "5"}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
-        **get_cookie_csrf(url="https://legulegu.com/stockdata/fund-position/pos-stock")
+        **get_cookie_csrf(url="https://legulegu.com/stockdata/fund-position/pos-stock"),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
@@ -57,12 +60,14 @@ def fund_balance_position_lg() -> pd.DataFrame:
         "category": "总仓位",
         "marketId": "5",
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
         **get_cookie_csrf(
             url="https://legulegu.com/stockdata/fund-position/pos-pingheng"
-        )
+        ),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
@@ -90,12 +95,14 @@ def fund_linghuo_position_lg() -> pd.DataFrame:
     url = "https://legulegu.com/api/stockdata/fund-position"
     token = get_token_lg()
     params = {"token": token, "type": "pos_linghuo", "category": "总仓位", "marketId": "5"}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
         **get_cookie_csrf(
             url="https://legulegu.com/stockdata/fund-position/pos-linghuo"
-        )
+        ),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)

--- a/akshare/fund/fund_rank_em.py
+++ b/akshare/fund/fund_rank_em.py
@@ -11,6 +11,7 @@ from datetime import datetime, date
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -72,7 +73,8 @@ def fund_open_fund_rank_em(symbol: str = "全部") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36",
         "Referer": "https://fund.eastmoney.com/fundguzhi.html",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): -1])
     temp_df = pd.DataFrame(data_json["datas"])
@@ -170,7 +172,8 @@ def fund_exchange_rank_em() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36",
         "Referer": "https://fund.eastmoney.com/fundguzhi.html",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     json_data = demjson.decode(text_data[text_data.find("{"): -1])
     temp_df = pd.DataFrame(json_data["datas"])
@@ -262,7 +265,8 @@ def fund_money_rank_em() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36",
         "Referer": "https://fund.eastmoney.com/fundguzhi.html",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["Data"])
     temp_df.reset_index(inplace=True)
@@ -361,7 +365,8 @@ def fund_lcx_rank_em() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36",
         "Referer": "https://fund.eastmoney.com/fundguzhi.html",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     try:
         data_json = r.json()
     except:
@@ -444,7 +449,8 @@ def fund_hk_rank_em() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36",
         "Referer": "https://fund.eastmoney.com/fundguzhi.html",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["Data"])
     temp_df.reset_index(inplace=True)

--- a/akshare/fund/fund_rating.py
+++ b/akshare/fund/fund_rating.py
@@ -7,6 +7,7 @@ https://fund.eastmoney.com/data/fundrating.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -18,7 +19,8 @@ def fund_rating_all() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://fund.eastmoney.com/data/fundrating.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     data_text = soup.find("div", attrs={"id": "fundinfo"}).find("script").string
     data_content = [
@@ -93,7 +95,8 @@ def fund_rating_sh(date: str = "20230630") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://fund.eastmoney.com/data/fundrating_3.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     date_list = [
         item["value"] for item in soup.find("select", attrs={"id": "rqoptions"})
@@ -102,7 +105,8 @@ def fund_rating_sh(date: str = "20230630") -> pd.DataFrame:
     if date_format not in date_list:
         raise "请访问 https://fund.eastmoney.com/data/fundrating_3.html 获取查询日期"
     url = f"https://fund.eastmoney.com/data/fundrating_3_{'-'.join([date[:4], date[4:6], date[6:]])}.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     data_text = soup.find("div", attrs={"id": "fundinfo"}).find("script").string
     data_content = [
@@ -183,7 +187,8 @@ def fund_rating_zs(date: str = "20230331") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://fund.eastmoney.com/data/fundrating_2.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     date_list = [
         item["value"] for item in soup.find("select", attrs={"id": "rqoptions"})
@@ -192,7 +197,8 @@ def fund_rating_zs(date: str = "20230331") -> pd.DataFrame:
     if date_format not in date_list:
         raise "请访问 https://fund.eastmoney.com/data/fundrating_2.html 获取查询日期"
     url = f"https://fund.eastmoney.com/data/fundrating_2_{'-'.join([date[:4], date[4:6], date[6:]])}.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     data_text = soup.find("div", attrs={"id": "fundinfo"}).find("script").string
     data_content = [
@@ -266,7 +272,8 @@ def fund_rating_ja(date: str = "20230331") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://fund.eastmoney.com/data/fundrating_4.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     date_list = [
         item["value"] for item in soup.find("select", attrs={"id": "rqoptions"})
@@ -275,7 +282,8 @@ def fund_rating_ja(date: str = "20230331") -> pd.DataFrame:
     if date_format not in date_list:
         raise "请访问 http://fund.eastmoney.com/data/fundrating_4.html 获取查询日期"
     url = f"https://fund.eastmoney.com/data/fundrating_4_{'-'.join([date[:4], date[4:6], date[6:]])}.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     data_text = soup.find("div", attrs={"id": "fundinfo"}).find("script").string
     data_content = [

--- a/akshare/fund/fund_report_cninfo.py
+++ b/akshare/fund/fund_report_cninfo.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/#/thematicStatistics
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -58,7 +59,8 @@ def fund_report_stock_cninfo(date: str = "20210630") -> pd.DataFrame:
     params = {
         "rdate": "-".join([date[:4], date[4:6], date[6:]]),
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.rename(
@@ -123,7 +125,8 @@ def fund_report_industry_allocation_cninfo(date: str = "20210630") -> pd.DataFra
     params = {
         "rdate": "-".join([date[:4], date[4:6], date[6:]]),
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.rename(
@@ -181,7 +184,8 @@ def fund_report_asset_allocation_cninfo() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.rename(

--- a/akshare/fund/fund_scale_em.py
+++ b/akshare/fund/fund_scale_em.py
@@ -7,6 +7,7 @@ https://fund.eastmoney.com/data/cyrjglist.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -27,14 +28,16 @@ def fund_scale_change_em() -> pd.DataFrame:
         "st": "desc",
         "sc": "reportdate",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): -1])
     total_page = data_json["pages"]
     big_df = pd.DataFrame()
     for page in range(1, int(total_page) + 1):
         params.update({"pi": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{"): -1])
         temp_df = pd.DataFrame(data_json["data"])
@@ -75,14 +78,16 @@ def fund_hold_structure_em() -> pd.DataFrame:
         "st": "desc",
         "sc": "reportdate",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): -1])
     total_page = data_json["pages"]
     big_df = pd.DataFrame()
     for page in range(1, int(total_page) + 1):
         params.update({"pi": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{"): -1])
         temp_df = pd.DataFrame(data_json["data"])

--- a/akshare/fund/fund_scale_sina.py
+++ b/akshare/fund/fund_scale_sina.py
@@ -7,6 +7,7 @@ https://vip.stock.finance.sina.com.cn/fund_center/index.html#jjgmall
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -37,7 +38,8 @@ def fund_scale_open_sina(symbol: str = "股票型基金") -> pd.DataFrame:
         "type2": fund_map[symbol],
         "type3": "",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("({") + 1: -2])
     temp_df = pd.DataFrame(data_json["data"])
@@ -105,7 +107,8 @@ def fund_scale_close_sina() -> pd.DataFrame:
         "type2": '',
         "type3": "",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("({") + 1: -2])
     temp_df = pd.DataFrame(data_json["data"])
@@ -173,7 +176,8 @@ def fund_scale_structured_sina() -> pd.DataFrame:
         "type2": '',
         "type3": "",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("({") + 1: -2])
     temp_df = pd.DataFrame(data_json["data"])

--- a/akshare/fund/fund_xq.py
+++ b/akshare/fund/fund_xq.py
@@ -8,6 +8,7 @@ https://danjuanfunds.com/funding/003545
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def fund_individual_basic_info_xq(
@@ -27,6 +28,7 @@ def fund_individual_basic_info_xq(
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(url, headers=headers, timeout=timeout)
     json_data = r.json()["data"]
     temp_df = pd.json_normalize(json_data)
@@ -92,6 +94,7 @@ def fund_individual_achievement_xq(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/80.0.3987.149 Safari/537.36"
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(url, headers=headers, timeout=timeout)
     json_data = r.json()["data"]
     combined_df = None
@@ -146,6 +149,7 @@ def fund_individual_analysis_xq(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/80.0.3987.149 Safari/537.36"
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(url, headers=headers, timeout=timeout)
     json_data = r.json()["data"]["index_data_list"]
     temp_df = pd.json_normalize(json_data)
@@ -199,6 +203,7 @@ def fund_individual_profit_probability_xq(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/80.0.3987.149 Safari/537.36"
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(url, headers=headers, timeout=timeout)
     json_data = r.json()["data"]["data_list"]
     temp_df = pd.DataFrame.from_dict(json_data, orient="columns")
@@ -238,6 +243,7 @@ def fund_individual_detail_info_xq(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/80.0.3987.149 Safari/537.36"
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(url, headers=headers, timeout=timeout)
     json_data = r.json()["data"]
     combined_df = None
@@ -290,6 +296,7 @@ def fund_individual_detail_hold_xq(
         "fund_code": f"{symbol}",
         "report_date": f"{'-'.join([date[:4], date[4:6], date[6:]])}",
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame.from_dict(data_json["data"]["chart_list"], orient="columns")

--- a/akshare/futures/futures_comex_em.py
+++ b/akshare/futures/futures_comex_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/pmetal/comex/by.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -37,7 +38,8 @@ def futures_comex_inventory(symbol: str = "黄金") -> pd.DataFrame:
         "client": "WEB",
         "filter": f'(INDICATOR_ID1="{symbol_map[symbol]}")(@STORAGE_TON<>"NULL")',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -48,7 +50,8 @@ def futures_comex_inventory(symbol: str = "黄金") -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], axis=0, ignore_index=True)

--- a/akshare/futures/futures_comm_ctp.py
+++ b/akshare/futures/futures_comm_ctp.py
@@ -7,6 +7,9 @@ http://openctp.cn/fees.html
 """
 
 import pandas as pd
+import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 
 
 def futures_fees_info() -> pd.DataFrame:
@@ -17,7 +20,10 @@ def futures_fees_info() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://openctp.cn/fees.html"
-    temp_df = pd.read_html(url)[0]
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    res.raise_for_status()
+    temp_df = pd.read_html(BytesIO(res.content))[0]
     return temp_df
 
 

--- a/akshare/futures/futures_comm_qihuo.py
+++ b/akshare/futures/futures_comm_qihuo.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -139,7 +140,8 @@ def _futures_comm_qihuo_process(df: pd.DataFrame, name: str = None) -> pd.DataFr
     common_temp_df["手续费"] = pd.to_numeric(common_temp_df["手续费"])
     common_temp_df["每跳净利"] = pd.to_numeric(common_temp_df["每跳净利"])
     url = "https://www.9qihuo.com/qihuoshouxufei"
-    r = requests.get(url, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, verify=False, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     raw_date_text = soup.find(name="a", attrs={"id": "dlink"}).previous
     comm_update_time = raw_date_text.split("，")[0].strip("（手续费更新时间：")
@@ -164,7 +166,8 @@ def futures_comm_info(symbol: str = "所有") -> pd.DataFrame:
 
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     url = "https://www.9qihuo.com/qihuoshouxufei"
-    r = requests.get(url, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, verify=False, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df.columns = [
         "合约品种",

--- a/akshare/futures/futures_contract_detail.py
+++ b/akshare/futures/futures_contract_detail.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_contract_detail(symbol: str = 'AP2101') -> pd.DataFrame:
@@ -21,7 +22,8 @@ def futures_contract_detail(symbol: str = 'AP2101') -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://finance.sina.com.cn/futures/quotes/{symbol}.shtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = 'gb2312'
     temp_df = pd.read_html(StringIO(r.text))[6]
     data_one = temp_df.iloc[:, :2]

--- a/akshare/futures/futures_daily_bar.py
+++ b/akshare/futures/futures_daily_bar.py
@@ -13,9 +13,11 @@ from io import BytesIO, StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures import cons
 from akshare.futures.requests_fun import requests_link
+from akshare.request_config_manager import get_headers_and_timeout
 
 calendar = cons.get_calendar()
 
@@ -34,7 +36,8 @@ def _futures_daily_czce(
     :rtype: pandas.DataFrame
     """
     url = f"http://www.czce.com.cn/cn/exchange/{dataset}.zip"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     with zipfile.ZipFile(BytesIO(r.content)) as file:
         with file.open(f"{dataset}.txt") as my_file:
             data = my_file.read().decode("gb2312")
@@ -122,7 +125,8 @@ def get_cffex_daily(date: str = "20100416") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/108.0.0.0 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     try:
         with zipfile.ZipFile(BytesIO(r.content)) as file:
             with file.open(f"{date}_1.csv") as my_file:
@@ -228,7 +232,8 @@ def get_gfex_daily(date: str = "20221223") -> pd.DataFrame:
         "X-Requested-With": "XMLHttpRequest",
         "content-type": "application/x-www-form-urlencoded",
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     try:
         data_json = r.json()
     except:  # noqa: E722
@@ -287,7 +292,8 @@ def get_ine_daily(date: str = "20220208") -> pd.DataFrame:
         # warnings.warn(f"{day.strftime('%Y%m%d')}非交易日")
         return pd.DataFrame()
     url = f"http://www.ine.cn/data/dailydata/kx/kx{day.strftime('%Y%m%d')}.dat"
-    r = requests.get(url, headers=cons.shfe_headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=cons.shfe_headers, timeout=timeout)
     result_df = pd.DataFrame()
     try:
         data_json = r.json()
@@ -365,7 +371,8 @@ def get_czce_daily(date: str = "20050525") -> pd.DataFrame:
         listed_columns = cons.CZCE_COLUMNS
         output_columns = cons.OUTPUT_COLUMNS
         try:
-            r = requests.get(url, headers=headers)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, headers=headers, timeout=timeout)
             if datetime.date(2015, 11, 12) <= day <= datetime.date(2017, 12, 27):
                 html = str(r.content, encoding="gbk")
             else:
@@ -557,7 +564,8 @@ def get_dce_daily(date: str = "20220308") -> pd.DataFrame:
         "day": date[6:],
         "exportFlag": "excel",
     }
-    r = requests.post(url, data=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=params, headers=headers, timeout=timeout)
     data_df = pd.read_excel(BytesIO(r.content), header=1)
 
     data_df = data_df[~data_df["商品名称"].str.contains("小计")]

--- a/akshare/futures/futures_foreign.py
+++ b/akshare/futures/futures_foreign.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures.futures_hq_sina import futures_foreign_commodity_subscribe_exchange_symbol
 
@@ -30,7 +31,8 @@ def futures_foreign_hist(symbol: str = "ZSD") -> pd.DataFrame:
         "_": today,
         "source": "web",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_df = pd.read_json(StringIO(data_text[data_text.find("["):-2]))
     return data_df
@@ -45,7 +47,8 @@ def futures_foreign_detail(symbol: str = "ZSD") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://finance.sina.com.cn/futures/quotes/{symbol}.shtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gbk"
     data_text = r.text
     data_df = pd.read_html(StringIO(data_text))[6]

--- a/akshare/futures/futures_hf_em.py
+++ b/akshare/futures/futures_hf_em.py
@@ -9,6 +9,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -31,7 +32,8 @@ def futures_global_em():
         'blockName': 'callback',
         '_': '1705570814466'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_num = data_json['total']
     total_page = math.ceil(total_num / 20) - 1
@@ -39,7 +41,8 @@ def futures_global_em():
     big_df = pd.DataFrame()
     for page in tqdm(range(total_page), leave=False):
         params.update({'pageIndex': page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['list'])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/futures/futures_hq_sina.py
+++ b/akshare/futures/futures_hq_sina.py
@@ -10,6 +10,7 @@ from typing import Union, List
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.utils import demjson
@@ -23,7 +24,8 @@ def _get_real_name_list() -> list:
     :rtype: list
     """
     url = "https://finance.sina.com.cn/money/future/hf.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     data_text = r.text
     need_text = data_text[
@@ -42,7 +44,8 @@ def futures_foreign_commodity_subscribe_exchange_symbol() -> list:
     :rtype: list
     """
     url = "https://finance.sina.com.cn/money/future/hf.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     data_text = r.text
     data_json = demjson.decode(
@@ -130,7 +133,8 @@ def futures_foreign_commodity_realtime(symbol: Union[str, List[str]]) -> pd.Data
         'Sec-Fetch-Site': 'cross-site',
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36'
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     data_df = pd.DataFrame(
         [
@@ -224,7 +228,8 @@ def futures_foreign_commodity_realtime(symbol: Union[str, List[str]]) -> pd.Data
 
     # 获取转换比例数据
     url = "https://finance.sina.com.cn/money/future/hf.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     soup = BeautifulSoup(r.text, "lxml")
     data_text = soup.find_all("script", attrs={"type": "text/javascript"})[
@@ -243,7 +248,8 @@ def futures_foreign_commodity_realtime(symbol: Union[str, List[str]]) -> pd.Data
 
     # 获取汇率数据
     url = "https://hq.sinajs.cn/?list=USDCNY"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     usd_rmb = float(
         data_text[data_text.find('"') + 1: data_text.find(",美元人民币")].split(",")[-1]

--- a/akshare/futures/futures_index_ccidx.py
+++ b/akshare/futures/futures_index_ccidx.py
@@ -9,6 +9,7 @@ from io import BytesIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_index_ccidx(symbol: str = "中证商品期货指数") -> pd.DataFrame:
@@ -26,7 +27,8 @@ def futures_index_ccidx(symbol: str = "中证商品期货指数") -> pd.DataFram
     }
     url = "http://www.ccidx.com/front/ajax_downZSHQ.do"
     params = {"indexCode": futures_index_map[symbol]}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_excel(BytesIO(r.content), header=1, engine="openpyxl")
     temp_df.columns = [
         "日期",
@@ -96,7 +98,8 @@ def futures_index_min_ccidx(symbol: str = "中证监控油脂油料期货指数"
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(
         [data_json["dataMap"]["axisList"], data_json["dataMap"]["lineList"]]

--- a/akshare/futures/futures_international.py
+++ b/akshare/futures/futures_international.py
@@ -9,6 +9,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.index.cons import short_headers, long_headers
@@ -24,7 +25,8 @@ def get_sector_symbol_name_url() -> dict:
     '商品指数': '/indices/commodities-indices'}
     """
     url = "https://cn.investing.com/commodities/"
-    res = requests.get(url, headers=short_headers)
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     name_url_option_list = soup.find_all(attrs={"class": "linkTitle"})  # 去掉-所有国家及地区
     url_list = [item.find("a")["href"] for item in name_url_option_list]
@@ -54,7 +56,8 @@ def futures_global_commodity_name_url_map(sector: str = "能源") -> dict:
     """
     name_url_dict = get_sector_symbol_name_url()
     url = f"https://cn.investing.com{name_url_dict[sector]}"
-    res = requests.post(url, headers=short_headers)
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.post(url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     url_list = [
         item.find("a")["href"].split("?")[0]
@@ -93,10 +96,12 @@ def futures_global_commodity_hist(
     end_date = "/".join([end_date[:4], end_date[4:6], end_date[6:]])
     name_code_dict = futures_global_commodity_name_url_map(sector)
     temp_url = f"https://cn.investing.com/{name_code_dict[symbol]}-historical-data"
-    res = requests.post(temp_url, headers=short_headers)
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.post(temp_url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     title = soup.find("h2", attrs={"class": "float_lang_base_1"}).get_text()
-    res = requests.post(temp_url, headers=short_headers)
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.post(temp_url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     data = soup.find_all(text=re.compile("window.histDataExcessInfo"))[0].strip()
     para_data = re.findall(r"\d+", data)
@@ -112,7 +117,8 @@ def futures_global_commodity_hist(
         "action": "historical_data",
     }
     url = "https://cn.investing.com/instruments/HistoricalDataAjax"
-    r = requests.post(url, data=payload, headers=long_headers)
+    long_headers, timeout = get_headers_and_timeout(locals().get('long_headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=long_headers, timeout=timeout)
     temp_df = pd.read_html(r.text)[0]
     temp_df["日期"] = pd.to_datetime(temp_df["日期"], format="%Y年%m月%d日")
     if any(temp_df["交易量"].astype(str).str.contains("-")):

--- a/akshare/futures/futures_inventory_99.py
+++ b/akshare/futures/futures_inventory_99.py
@@ -9,6 +9,8 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.futures.cons import (
@@ -224,12 +226,14 @@ def futures_inventory_99(
             session = requests.Session()
             url = "http://service.99qh.com/Storage/Storage.aspx"
             params = {"page": "99qh"}
-            r = session.post(url, params=params, headers=sample_headers)
+            sample_headers, timeout = get_headers_and_timeout(locals().get('sample_headers', {}), locals().get('timeout', None))
+            r = session.post(url, params=params, headers=sample_headers, timeout=timeout)
             cookie = r.cookies.get_dict()
             url = "http://service.99qh.com/Storage/Storage.aspx"
             params = {"page": "99qh"}
+            sample_headers, timeout = get_headers_and_timeout(locals().get('sample_headers', {}), locals().get('timeout', None))
             r = requests.post(
-                url, params=params, headers=sample_headers, cookies=cookie
+                url, params=params, headers=sample_headers, cookies=cookie, timeout=timeout
             )
             soup = BeautifulSoup(r.text, "lxml")
             view_state = soup.find_all(attrs={"id": "__VIEWSTATE"})[0]["value"]
@@ -246,12 +250,14 @@ def futures_inventory_99(
                 "ddlExchName": int(exchange),
                 "ddlGoodsName": 1,
             }
+            qh_headers, timeout = get_headers_and_timeout(locals().get('qh_headers', {}), locals().get('timeout', None))
             res = requests.post(
                 url,
                 params={"page": "99qh"},
                 data=payload,
                 headers=qh_headers,
                 cookies=cookie,
+                timeout=timeout
             )
             soup = BeautifulSoup(res.text, "lxml")
             view_state = soup.find_all(attrs={"id": "__VIEWSTATE"})[0]["value"]
@@ -268,12 +274,14 @@ def futures_inventory_99(
                 "ddlExchName": int(exchange),
                 "ddlGoodsName": int(symbol),
             }
+            qh_headers, timeout = get_headers_and_timeout(locals().get('qh_headers', {}), locals().get('timeout', None))
             res = requests.post(
                 url,
                 params=params,
                 data=payload,
                 headers=qh_headers,
                 cookies=cookie,
+                timeout=timeout
             )
             data_df = pd.read_html(StringIO(res.text))[-1].T
             data_df.columns = data_df.iloc[0, :]

--- a/akshare/futures/futures_inventory_em.py
+++ b/akshare/futures/futures_inventory_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/ifdata/kcsj.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_inventory_em(symbol: str = "沪铝") -> pd.DataFrame:
@@ -29,7 +30,8 @@ def futures_inventory_em(symbol: str = "沪铝") -> pd.DataFrame:
         "client": "WEB",
         "_": "1669352163467",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     symbol_dict = dict(zip(temp_df["TRADE_TYPE"], temp_df["TRADE_CODE"]))
@@ -47,7 +49,8 @@ def futures_inventory_em(symbol: str = "沪铝") -> pd.DataFrame:
         "client": "WEB",
         "_": "1669352163467",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
 

--- a/akshare/futures/futures_news_baidu.py
+++ b/akshare/futures/futures_news_baidu.py
@@ -7,6 +7,7 @@ https://gushitong.baidu.com/futures/ab-CJ888
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_news_baidu(symbol: str = "AL") -> pd.DataFrame:
@@ -20,7 +21,8 @@ def futures_news_baidu(symbol: str = "AL") -> pd.DataFrame:
     """
     url = "https://finance.pae.baidu.com/vapi/getfuturesnews"
     params = {"code": f"{symbol}888", "pn": "0", "rn": "2000", "finClientType": "pc"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["Result"])
     temp_df.rename(

--- a/akshare/futures/futures_news_shmet.py
+++ b/akshare/futures/futures_news_shmet.py
@@ -8,6 +8,7 @@ https://www.shmet.com/newsFlash/newsFlash.html?searchKeyword=
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_news_shmet(symbol: str = "全部") -> pd.DataFrame:
@@ -42,7 +43,8 @@ def futures_news_shmet(symbol: str = "全部") -> pd.DataFrame:
             "content": "",
             "flashTag": symbol_map[symbol],
         }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["dataList"])
     temp_df.columns = [

--- a/akshare/futures/futures_rule.py
+++ b/akshare/futures/futures_rule.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_rule(date: str = "20231205") -> pd.DataFrame:
@@ -24,7 +25,8 @@ def futures_rule(date: str = "20231205") -> pd.DataFrame:
     urllib3.disable_warnings()
     url = " https://www.gtjaqh.com/pc/calendar"
     params = {"date": f"{date}"}
-    r = requests.get(url, params=params, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, verify=False, headers=headers, timeout=timeout)
     big_df = pd.read_html(StringIO(r.text), header=1)[0]
     big_df["交易保证金比例"] = big_df["交易保证金比例"].str.strip("%")
     big_df["交易保证金比例"] = pd.to_numeric(big_df["交易保证金比例"], errors="coerce")

--- a/akshare/futures/futures_settlement_price_sgx.py
+++ b/akshare/futures/futures_settlement_price_sgx.py
@@ -12,6 +12,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def __fetch_ftse_index_futu(date: str = "20231108") -> int:
@@ -36,7 +37,8 @@ def __fetch_ftse_index_futu(date: str = "20231108") -> int:
         'ut': 'f057cbcbce2a86e2866ab8877db1d059',
         'forcect': '1',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json['data']['klines']])
     temp_df.columns = ['date', "-", "open", "close", "high", "low", "volume", "amount", "_", "-", "open", "close",
@@ -56,7 +58,8 @@ def futures_settlement_price_sgx(date: str = "20231107") -> pd.DataFrame:
     """
     num = __fetch_ftse_index_futu(date)
     url = f"https://links.sgx.com/1.0.0/derivatives-daily/{num}/FUTURE.zip"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     with zipfile.ZipFile(BytesIO(r.content)) as file:
         with file.open(file.namelist()[0]) as my_file:
             data = my_file.read().decode()

--- a/akshare/futures/futures_spot_stock_em.py
+++ b/akshare/futures/futures_spot_stock_em.py
@@ -8,6 +8,7 @@ https://data.eastmoney.com/ifdata/xhgp.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -45,7 +46,8 @@ def futures_spot_stock(symbol: str = "能源") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     temp_json = demjson.decode(
         data_text[

--- a/akshare/futures/futures_stock_js.py
+++ b/akshare/futures/futures_stock_js.py
@@ -8,6 +8,7 @@ https://www.shfe.com.cn/statements/dataview.html?paramid=kx
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_stock_shfe_js(date: str = "20240223") -> pd.DataFrame:
@@ -32,7 +33,8 @@ def futures_stock_shfe_js(date: str = "20240223") -> pd.DataFrame:
         'attr_id': '1',
         '_': '1708761356458',
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     columns_list = [item['name'] for item in data_json['data']['keys']]
     temp_df = pd.DataFrame(data_json['data']['values'], columns=columns_list)

--- a/akshare/futures/futures_to_spot.py
+++ b/akshare/futures/futures_to_spot.py
@@ -8,6 +8,7 @@ from io import StringIO, BytesIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_to_spot_shfe(date: str = "202312") -> pd.DataFrame:
@@ -25,7 +26,8 @@ def futures_to_spot_shfe(date: str = "202312") -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["ExchangeDelivery"])
     temp_df.columns = [
@@ -79,7 +81,8 @@ def futures_delivery_dce(date: str = "202312") -> pd.DataFrame:
         "Upgrade-Insecure-Requests": "1",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df["交割日期"] = (
         temp_df["交割日期"].astype(str).str.split(".", expand=True).iloc[:, 0]
@@ -109,7 +112,8 @@ def futures_to_spot_dce(date: str = "202312") -> pd.DataFrame:
         "ftsDealQuotes.begin_month": date,
         "ftsDealQuotes.end_month": date,
     }
-    r = requests.post(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df["期转现发生日期"] = (
         temp_df["期转现发生日期"].astype(str).str.split(".", expand=True).iloc[:, 0]
@@ -136,7 +140,8 @@ def futures_delivery_match_dce(symbol: str = "a") -> pd.DataFrame:
         "contract.contract_id": "all",
         "contract.variety_id": symbol,
     }
-    r = requests.post(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df["配对日期"] = (
         temp_df["配对日期"].astype(str).str.split(".", expand=True).iloc[:, 0]
@@ -170,7 +175,8 @@ def futures_to_spot_czce(date: str = "20231228") -> pd.DataFrame:
         "Upgrade-Insecure-Requests": "1",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     temp_df = pd.read_excel(BytesIO(r.content), skiprows=1)
 
@@ -201,7 +207,8 @@ def futures_delivery_match_czce(date: str = "20210106") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"http://www.czce.com.cn/cn/DFSStaticFiles/Future/{date[:4]}/{date}/FutureDataDelsettle.xls"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     temp_df = pd.read_excel(BytesIO(r.content), skiprows=0)
     index_flag = temp_df[temp_df.iloc[:, 0].str.contains("配对日期")].index.values
@@ -249,7 +256,8 @@ def futures_delivery_czce(date: str = "20210112") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"http://www.czce.com.cn/cn/DFSStaticFiles/Future/{date[:4]}/{date}/FutureDataSettlematched.xls"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     temp_df = pd.read_excel(BytesIO(r.content), skiprows=1)
     temp_df.columns = [
@@ -279,7 +287,8 @@ def futures_delivery_shfe(date: str = "202312") -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["o_curdelivery"])

--- a/akshare/futures/futures_warehouse_receipt.py
+++ b/akshare/futures/futures_warehouse_receipt.py
@@ -18,6 +18,7 @@ from io import BytesIO, StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_czce_warehouse_receipt(date: str = "20200702") -> dict:
@@ -33,7 +34,8 @@ def futures_czce_warehouse_receipt(date: str = "20200702") -> dict:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
     }
-    r = requests.get(url, verify=False, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, verify=False, headers=headers, timeout=timeout)
     temp_df = pd.read_excel(BytesIO(r.content))
     index_list = temp_df[temp_df.iloc[:, 0].str.find("品种") == 0.0].index.to_list()
     index_list.append(len(temp_df))
@@ -70,7 +72,8 @@ def futures_dce_warehouse_receipt(date: str = "20200702") -> dict:
         "month": str(int(date[4:6]) - 1),
         "day": date[6:],
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     index_list = temp_df[temp_df.iloc[:, 0].str.contains("小计") == 1].index.to_list()
     index_list.insert(0, 0)
@@ -106,7 +109,8 @@ def futures_shfe_warehouse_receipt(date: str = "20200702") -> dict:
     }
     url = f"http://www.shfe.com.cn/data/dailydata/{date}dailystock.dat"
     if date >= "20140519":
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["o_cursor"])
         temp_df["VARNAME"] = temp_df["VARNAME"].str.split(r"$", expand=True).iloc[:, 0]
@@ -119,7 +123,8 @@ def futures_shfe_warehouse_receipt(date: str = "20200702") -> dict:
             big_dict[item] = temp_df[temp_df["VARNAME"] == item]
     else:
         url = f"http://www.shfe.com.cn/data/dailydata/{date}dailystock.html"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0]
         index_list = temp_df[
             temp_df.iloc[:, 3].str.contains("单位：") == 1
@@ -158,7 +163,8 @@ def futures_gfex_warehouse_receipt(date: str = "20240122") -> dict:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
     }
     payload = {"gen_date": date}
-    r = requests.post(url=url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url=url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     symbol_list = list(

--- a/akshare/futures/futures_zh_sina.py
+++ b/akshare/futures/futures_zh_sina.py
@@ -13,6 +13,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.futures.cons import (
@@ -35,7 +36,8 @@ def futures_symbol_mark() -> pd.DataFrame:
     url = (
         "https://vip.stock.finance.sina.com.cn/quotes_service/view/js/qihuohangqing.js"
     )
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     data_text = r.text
     raw_json = data_text[data_text.find("{") : data_text.find("}") + 1]
@@ -109,7 +111,8 @@ def futures_zh_realtime(symbol: str = "白糖") -> pd.DataFrame:
         "node": symbol_mark_map[symbol],
         "base": "futures",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
 
@@ -145,7 +148,8 @@ def zh_subscribe_exchange_symbol(symbol: str = "cffex") -> pd.DataFrame:
     :return: 交易所具体的可交易品种
     :rtype: dict
     """
-    r = requests.get(zh_subscribe_exchange_symbol_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(zh_subscribe_exchange_symbol_url, headers=headers, timeout=timeout)
     r.encoding = "gbk"
     data_text = r.text
     data_json = demjson.decode(
@@ -182,8 +186,9 @@ def match_main_contract(symbol: str = "cffex") -> str:
     for item in exchange_symbol_list:
         # item = 'sngz_qh'
         zh_match_main_contract_payload.update({"node": item})
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         res = requests.get(
-            zh_match_main_contract_url, params=zh_match_main_contract_payload
+            zh_match_main_contract_url, params=zh_match_main_contract_payload, headers=headers, timeout=timeout
         )
         data_json = demjson.decode(res.text)
         data_df = pd.DataFrame(data_json)
@@ -236,7 +241,8 @@ def futures_zh_spot(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/97.0.4692.71 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_df = pd.DataFrame(
         [
             item.strip().split("=")[1].split(",")
@@ -628,7 +634,8 @@ def futures_zh_minute_sina(symbol: str = "IF2008", period: str = "5") -> pd.Data
         "symbol": symbol,
         "type": period,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.DataFrame(json.loads(r.text.split("=(")[1].split(");")[0]))
     temp_df.columns = [
         "datetime",
@@ -666,7 +673,8 @@ def futures_zh_daily_sina(symbol: str = "RB0") -> pd.DataFrame:
         "symbol": symbol,
         "type": "_".join([date[:4], date[4:6], date[6:]]),
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.DataFrame(json.loads(r.text.split("=(")[1].split(");")[0]))
     temp_df.columns = [
         "date",

--- a/akshare/futures/inventory_data.py
+++ b/akshare/futures/inventory_data.py
@@ -5,6 +5,7 @@ Date: 2021/1/10 13:58
 Desc: 得到 99 期货网的原始数据
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pickle
 from bs4 import BeautifulSoup
 import time
@@ -20,7 +21,8 @@ sample_headers = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36"
 }
 
-res = requests.get(url, headers=sample_headers)
+headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+res = requests.get(url, headers=sample_headers, timeout=timeout)
 
 soup = BeautifulSoup(res.text, "lxml")
 view_state = soup.find_all(attrs={"id": "__VIEWSTATE"})[0]["value"]
@@ -69,7 +71,8 @@ for i in code_temp_list:
                 # "ddlGoodsName": 6
             }
 
-            res = requests.post(url, data=payload, headers=qh_headers)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            res = requests.post(url, data=payload, headers=qh_headers, timeout=timeout)
             soup = BeautifulSoup(res.text, "lxml")
             exchange = soup.find_all("select")[0].find_all(attrs={"selected": "selected"})[0].get_text()
             print(exchange)

--- a/akshare/futures/receipt.py
+++ b/akshare/futures/receipt.py
@@ -13,9 +13,11 @@ from typing import List
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures import cons
 from akshare.futures.requests_fun import requests_link, pandas_read_html_link
+from akshare.request_config_manager import get_headers_and_timeout
 from akshare.futures.symbol_var import chinese_to_english
 
 calendar = cons.get_calendar()
@@ -237,7 +239,8 @@ def get_czce_receipt_2(date: str = None, vars_list: List = cons.contract_symbols
         warnings.warn('%s非交易日' % date.strftime('%Y%m%d'))
         return None
     url = cons.CZCE_RECEIPT_URL_2 % (date[:4], date)
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = 'utf-8'
     data = pd.read_html(r.text)[3:]
     records = pd.DataFrame()
@@ -380,7 +383,8 @@ def get_gfex_receipt(date: str = None, vars_list: List = cons.contract_symbols) 
         "X-Requested-With": "XMLHttpRequest",
         "content-type": "application/x-www-form-urlencoded"
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['data'])
     temp_df = temp_df[temp_df['variety'].str.contains("小计")]

--- a/akshare/futures/requests_fun.py
+++ b/akshare/futures/requests_fun.py
@@ -10,6 +10,7 @@ from typing import Dict
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def requests_link(url: str, encoding: str = "utf-8", method: str = "get", data: Dict = None, headers: Dict = None):
@@ -26,11 +27,15 @@ def requests_link(url: str, encoding: str = "utf-8", method: str = "get", data: 
     while True:
         try:
             if method == "get":
-                r = requests.get(url, timeout=20, headers=headers)
+                timeout = 20
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(url, timeout=timeout, headers=headers)
                 r.encoding = encoding
                 return r
             elif method == "post":
-                r = requests.post(url, timeout=20, data=data, headers=headers)
+                timeout = 20
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.post(url, timeout=timeout, data=data, headers=headers)
                 r.encoding = encoding
                 return r
             else:
@@ -57,12 +62,16 @@ def pandas_read_html_link(url: str, encoding: str = "utf-8", method: str = "get"
     while True:
         try:
             if method == "get":
-                r = requests.get(url, timeout=20)
+                timeout = 20
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(url, timeout=timeout, headers=headers)
                 r.encoding = encoding
                 r = pd.read_html(StringIO(r.text), encoding=encoding)
                 return r
             elif method == "post":
-                r = requests.post(url, timeout=20, data=data, headers=headers)
+                timeout = 20
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.post(url, timeout=timeout, data=data, headers=headers)
                 r.encoding = encoding
                 r = pd.read_html(StringIO(r.text), encoding=encoding)
                 return r

--- a/akshare/futures_derivative/futures_contract_info_cffex.py
+++ b/akshare/futures_derivative/futures_contract_info_cffex.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree as ET
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_contract_info_cffex(date: str = "20240228") -> pd.DataFrame:
@@ -22,7 +23,8 @@ def futures_contract_info_cffex(date: str = "20240228") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
     }
     url = f"http://www.cffex.com.cn/sj/jycs/{date[:6]}/{date[6:]}/index.xml"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     xml_data = r.text
     # 解析 XML
     tree = ET.ElementTree(ET.fromstring(xml_data))

--- a/akshare/futures_derivative/futures_contract_info_czce.py
+++ b/akshare/futures_derivative/futures_contract_info_czce.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_contract_info_czce(date: str = "20240228") -> pd.DataFrame:
@@ -27,7 +28,8 @@ def futures_contract_info_czce(date: str = "20240228") -> pd.DataFrame:
         "Host": "www.czce.com.cn",
     }
     url = f"http://www.czce.com.cn/cn/DFSStaticFiles/Future/{date[:4]}/{date}/FutureDataReferenceData.xml"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     xml_data = r.text
     # 解析 XML
     tree = ET.ElementTree(ET.fromstring(xml_data))

--- a/akshare/futures_derivative/futures_contract_info_dce.py
+++ b/akshare/futures_derivative/futures_contract_info_dce.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_contract_info_dce() -> pd.DataFrame:
@@ -23,7 +24,8 @@ def futures_contract_info_dce() -> pd.DataFrame:
         'contractInformation.variety': 'all',
         'contractInformation.trade_type': '0',
     }
-    r = requests.post(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df['交易单位'] = pd.to_numeric(temp_df['交易单位'], errors="coerce")
     temp_df['最小变动价位'] = pd.to_numeric(temp_df['最小变动价位'], errors="coerce")

--- a/akshare/futures_derivative/futures_contract_info_gfex.py
+++ b/akshare/futures_derivative/futures_contract_info_gfex.py
@@ -7,6 +7,7 @@ http://www.gfex.com.cn/gfex/hyxx/ywcs.shtml
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_contract_info_gfex() -> pd.DataFrame:
@@ -24,7 +25,8 @@ def futures_contract_info_gfex() -> pd.DataFrame:
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['data'])
     temp_df.rename(columns={

--- a/akshare/futures_derivative/futures_contract_info_ine.py
+++ b/akshare/futures_derivative/futures_contract_info_ine.py
@@ -7,6 +7,7 @@ https://www.ine.cn/bourseService/summary/?name=currinstrumentprop
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_contract_info_ine(date: str = "20240228") -> pd.DataFrame:
@@ -25,7 +26,8 @@ def futures_contract_info_ine(date: str = "20240228") -> pd.DataFrame:
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['ContractBaseInfo'])
     temp_df.rename(columns={

--- a/akshare/futures_derivative/futures_contract_info_shfe.py
+++ b/akshare/futures_derivative/futures_contract_info_shfe.py
@@ -8,6 +8,7 @@ https://www.shfe.com.cn/bourseService/businessdata/summaryinquiry/
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_contract_info_shfe(date: str = "20240227") -> pd.DataFrame:
@@ -24,7 +25,8 @@ def futures_contract_info_shfe(date: str = "20240227") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/119.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["ContractBaseInfo"])
     temp_df.rename(

--- a/akshare/futures_derivative/futures_cot_sina.py
+++ b/akshare/futures_derivative/futures_cot_sina.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_hold_pos_sina(
@@ -29,7 +30,8 @@ def futures_hold_pos_sina(
     date = '-'.join([date[:4], date[4:6], date[6:]])
     url = "https://vip.stock.finance.sina.com.cn/q/view/vCffex_Positions_cjcc.php"
     params = {"symbol": contract, "date": date}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     if symbol == "成交量":
         temp_df = pd.read_html(StringIO(r.text))[2].iloc[:-1, :]
         temp_df['名次'] = pd.to_numeric(temp_df['名次'], errors="coerce")

--- a/akshare/futures_derivative/futures_hog.py
+++ b/akshare/futures_derivative/futures_hog.py
@@ -8,6 +8,7 @@ https://zhujia.zhuwang.com.cn
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_hog_core(symbol: str = "外三元") -> pd.DataFrame:
@@ -22,7 +23,8 @@ def futures_hog_core(symbol: str = "外三元") -> pd.DataFrame:
     if symbol == "外三元":
         url = "https://xt.yangzhu.vip/data/getzhujiahitsdata"
         params = {"ptype": "1", "areano": "-1", "datetype": "0"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["value", "date"]
@@ -33,7 +35,8 @@ def futures_hog_core(symbol: str = "外三元") -> pd.DataFrame:
     elif symbol == "内三元":
         url = "https://xt.yangzhu.vip/data/getzhujiahitsdata"
         params = {"ptype": "2", "areano": "-1", "datetype": "0"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["value", "date"]
@@ -44,7 +47,8 @@ def futures_hog_core(symbol: str = "外三元") -> pd.DataFrame:
     elif symbol == "土杂猪":
         url = "https://xt.yangzhu.vip/data/getzhujiahitsdata"
         params = {"ptype": "3", "areano": "-1", "datetype": "0"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["value", "date"]
@@ -66,7 +70,8 @@ def futures_hog_cost(symbol: str = "玉米") -> pd.DataFrame:
     if symbol == "玉米":
         url = "https://xt.yangzhu.vip/data/getzhujiahitsdata"
         params = {"ptype": "4", "areano": "-1", "datetype": "0"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["value", "date"]
@@ -77,7 +82,8 @@ def futures_hog_cost(symbol: str = "玉米") -> pd.DataFrame:
     elif symbol == "豆粕":
         url = "https://xt.yangzhu.vip/data/getzhujiahitsdata"
         params = {"ptype": "5", "areano": "-1", "datetype": "0"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["value", "date"]
@@ -91,7 +97,8 @@ def futures_hog_cost(symbol: str = "玉米") -> pd.DataFrame:
             "ptype": "1",
             "areano": "-1",
         }
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["date", "value"]
@@ -104,7 +111,8 @@ def futures_hog_cost(symbol: str = "玉米") -> pd.DataFrame:
             "ptype": "2",
             "areano": "-1",
         }
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["date", "value"]
@@ -126,7 +134,8 @@ def futures_hog_supply(symbol: str = "猪肉批发价") -> pd.DataFrame:
     if symbol == "猪肉批发价":
         url = "https://xt.yangzhu.vip/data/getmapdata"
         params = {"ptype": "3", "areano": "-1"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["date", "item", "value"]
@@ -137,7 +146,8 @@ def futures_hog_supply(symbol: str = "猪肉批发价") -> pd.DataFrame:
     elif symbol == "储备冻猪肉":
         url = "https://xt.yangzhu.vip/data/getmapdata"
         params = {"ptype": "4", "areano": "-1"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["date", "value"]
@@ -147,7 +157,8 @@ def futures_hog_supply(symbol: str = "猪肉批发价") -> pd.DataFrame:
     elif symbol == "饲料原料数据":
         url = "https://xt.yangzhu.vip/data/getmapdata"
         params = {"ptype": "5", "areano": "-1"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = [
@@ -174,7 +185,8 @@ def futures_hog_supply(symbol: str = "猪肉批发价") -> pd.DataFrame:
     elif symbol == "白条肉":
         url = "https://xt.yangzhu.vip/data/getmapdata"
         params = {"ptype": "6", "areano": "-1"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["周期", "白条肉平均出厂价格", "环比", "同比"]
@@ -187,7 +199,8 @@ def futures_hog_supply(symbol: str = "猪肉批发价") -> pd.DataFrame:
     elif symbol == "生猪产能":
         url = "https://xt.yangzhu.vip/data/getmapdata"
         params = {"ptype": "7", "areano": "-1"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["周期", "能繁母猪存栏", "猪肉产量", "生猪存栏", "生猪出栏"]
@@ -201,7 +214,8 @@ def futures_hog_supply(symbol: str = "猪肉批发价") -> pd.DataFrame:
     elif symbol == "育肥猪":
         url = "https://xt.yangzhu.vip/data/getmapdata"
         params = {"ptype": "9", "areano": "-1"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df = temp_df[["date", "benzhou"]]
@@ -211,7 +225,8 @@ def futures_hog_supply(symbol: str = "猪肉批发价") -> pd.DataFrame:
     elif symbol == "肉类价格指数":
         url = "https://xt.yangzhu.vip/data/getmapdata"
         params = {"ptype": "10", "areano": "-1"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["date", "item", "value"]
@@ -222,7 +237,8 @@ def futures_hog_supply(symbol: str = "猪肉批发价") -> pd.DataFrame:
     elif symbol == "猪粮比价":
         url = "https://xt.yangzhu.vip/data/getmapdata"
         params = {"ptype": "11", "areano": "-1"}
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df.columns = ["date", "value"]

--- a/akshare/futures_derivative/futures_index_price_nh.py
+++ b/akshare/futures_derivative/futures_index_price_nh.py
@@ -11,6 +11,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_index_symbol_table_nh() -> pd.DataFrame:
@@ -21,7 +22,8 @@ def futures_index_symbol_table_nh() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://www.nanhua.net/ianalysis/plate-variety.json"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
     temp_df["firstday"] = pd.to_datetime(temp_df["firstday"], errors="coerce").dt.date
@@ -42,7 +44,8 @@ def futures_price_index_nh(symbol: str = "A") -> pd.DataFrame:
     if symbol in symbol_list:
         t = time.time()
         url = f"https://www.nanhua.net/ianalysis/varietyindex/price/{symbol}.json?t={int(round(t * 1000))}"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json)
         temp_df.columns = ["date", "value"]

--- a/akshare/futures_derivative/futures_index_return_nh.py
+++ b/akshare/futures_derivative/futures_index_return_nh.py
@@ -11,6 +11,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures_derivative.futures_index_price_nh import (
     futures_index_symbol_table_nh,
@@ -31,7 +32,8 @@ def futures_return_index_nh(symbol: str = "Y") -> pd.DataFrame:
     if symbol in symbol_list:
         t = time.time()
         url = f"https://www.nanhua.net/ianalysis/varietyindex/index/{symbol}.json?t={int(round(t * 1000))}"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json)
         temp_df.columns = ["date", "value"]

--- a/akshare/futures_derivative/futures_index_sina.py
+++ b/akshare/futures_derivative/futures_index_sina.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures.cons import (
     zh_subscribe_exchange_symbol_url,
@@ -27,7 +28,8 @@ def zh_subscribe_exchange_symbol(symbol: str = "dce") -> pd.DataFrame:
     :return: 订阅指定交易所品种的代码
     :rtype: pandas.DataFrame
     """
-    r = requests.get(zh_subscribe_exchange_symbol_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(zh_subscribe_exchange_symbol_url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): data_text.find("};") + 1])
@@ -61,6 +63,7 @@ def match_main_contract(symbol: str = "shfe") -> pd.DataFrame:
     exchange_symbol_list = zh_subscribe_exchange_symbol(symbol).iloc[:, 1].tolist()
     for item in exchange_symbol_list:
         zh_match_main_contract_payload.update({"node": item})
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         res = requests.get(
             zh_match_main_contract_url, params=zh_match_main_contract_payload
         )
@@ -117,7 +120,8 @@ def futures_main_sina(
     trade_date = "20210817"
     trade_date = trade_date[:4] + "_" + trade_date[4:6] + "_" + trade_date[6:]
     url = f"https://stock2.finance.sina.com.cn/futures/api/jsonp.php/var%20_{symbol}{trade_date}=/InnerFuturesNewService.getDailyKLine?symbol={symbol}&_={trade_date}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = data_text[data_text.find("([") + 1: data_text.rfind("])") + 1]
     temp_df = pd.read_json(StringIO(data_json))

--- a/akshare/futures_derivative/futures_index_volatility_nh.py
+++ b/akshare/futures_derivative/futures_index_volatility_nh.py
@@ -11,6 +11,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures_derivative.futures_index_price_nh import (
     futures_index_symbol_table_nh,
@@ -34,7 +35,8 @@ def futures_volatility_index_nh(
     if symbol in symbol_df["code"].tolist():
         t = time.time()
         url = f"https://www.nanhua.net/ianalysis/volatility/{period}/{symbol}.json?t={int(round(t * 1000))}"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json)
         temp_df.columns = ["date", "value"]

--- a/akshare/futures_derivative/futures_other_index_nh.py
+++ b/akshare/futures_derivative/futures_other_index_nh.py
@@ -12,6 +12,7 @@ https://www.nanhua.net/nhzc/correltable.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def futures_board_index_nh(start_date: str = "20231110", end_date: str = "20231116") -> pd.DataFrame:
@@ -30,7 +31,8 @@ def futures_board_index_nh(start_date: str = "20231110", end_date: str = "202311
     params = {
         't': '1649920913503'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     start_df = pd.DataFrame(r.json())
     start_df.columns = [
         'name',
@@ -43,7 +45,8 @@ def futures_board_index_nh(start_date: str = "20231110", end_date: str = "202311
     params = {
         't': '1649920913503'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     end_df = pd.DataFrame(r.json())
     end_df.columns = [
         'name',
@@ -77,7 +80,8 @@ def futures_variety_index_nh(start_date: str = "20231110", end_date: str = "2023
     params = {
         't': '1649920913503'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     start_df = pd.DataFrame(r.json())
     start_df.columns = [
         'name',
@@ -89,7 +93,8 @@ def futures_variety_index_nh(start_date: str = "20231110", end_date: str = "2023
     params = {
         't': '1649920913503'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     end_df = pd.DataFrame(r.json())
     end_df.columns = [
         'name',
@@ -121,7 +126,8 @@ def futures_correlation_nh(date: str = "20231110", period: str = "20") -> pd.Dat
     params = {
         't': '1649920913503'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.DataFrame(r.json())
     temp_df.columns = [
         '品种代码1',

--- a/akshare/futures_derivative/futures_spot_sys.py
+++ b/akshare/futures_derivative/futures_spot_sys.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -21,7 +22,8 @@ def __get_sys_spot_futures_dict() -> dict:
     :rtype: dict
     """
     url = "https://www.100ppi.com/sf/792.html"
-    res = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(res.text, features="lxml")
     temp_item = soup.find(name="div", attrs={"class": "q8"}).find_all("li")
     name_url_dict = dict(
@@ -46,7 +48,8 @@ def futures_spot_sys(symbol: str = "铜", indicator: str = "市场价格") -> pd
     """
     name_url_dict = __get_sys_spot_futures_dict()
     url = name_url_dict[symbol]
-    r = requests.get("https://www.100ppi.com" + url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get("https://www.100ppi.com" + url, headers=headers, timeout=timeout)
     if indicator == "市场价格":
         table_df_one = pd.read_html(StringIO(r.text), header=0, index_col=0)[1].T
         table_df_one["现货价格"] = pd.to_numeric(

--- a/akshare/fx/currency_investing.py
+++ b/akshare/fx/currency_investing.py
@@ -10,6 +10,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -23,7 +24,8 @@ def _currency_name_url() -> dict:
     :rtype: dict
     """
     url = "https://cn.investing.com/currencies/"
-    res = requests.post(url, headers=short_headers)
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.post(url, headers=short_headers, timeout=timeout)
     data_table = pd.read_html(res.text)[0].iloc[:, 1:]  # 实时货币行情
     data_table.columns = ["中文名称", "英文名称", "最新", "最高", "最低", "涨跌额", "涨跌幅", "时间"]
     name_code_dict = dict(
@@ -49,7 +51,8 @@ def currency_hist_area_index_name_code(symbol: str = "usd-jpy") -> dict:
     """
     pd.set_option("mode.chained_assignment", None)
     url = f"https://cn.investing.com/currencies/{symbol}-historical-data"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     data_text = soup.find("script", attrs={"id": "__NEXT_DATA__"}).text
     data_json = json.loads(data_text)
@@ -107,7 +110,8 @@ def currency_hist(
         "sec-fetch-site": "same-site",
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     df_data = pd.DataFrame(data_json["data"])
     df_data.columns = [
@@ -148,7 +152,8 @@ def _currency_single() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://cn.investing.com/currencies/single-currency-crosses"
-    res = requests.post(url, headers=short_headers)
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.post(url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     name_url_option_list = soup.find(
         "select", attrs={"class": "newInput selectBox"}
@@ -205,7 +210,8 @@ def currency_name_code(symbol: str = "usd/jpy") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(r.json()["HTML"])[0].iloc[:, 1:]
     temp_df.rename(columns={"名称.1": "简称"}, inplace=True)
     temp_df["pids"] = [item[:-1] for item in r.json()["pids"]]
@@ -238,7 +244,8 @@ def currency_name_code(symbol: str = "usd/jpy") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(r.json()["HTML"])[0].iloc[:, 1:]
     temp_df.rename(columns={"名称.1": "简称"}, inplace=True)
     temp_df["pids"] = [item[:-1] for item in r.json()["pids"]]
@@ -291,7 +298,8 @@ def currency_pair_map(symbol: str = "美元") -> pd.DataFrame:
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
             "X-Requested-With": "XMLHttpRequest",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         soup = BeautifulSoup(r.text, "lxml")
         region_code.extend(
             [
@@ -312,7 +320,8 @@ def currency_pair_map(symbol: str = "美元") -> pd.DataFrame:
         "region_ID": name_id_map[symbol].split("-")[1],
         "currency_ID": name_id_map[symbol].split("-")[0],
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
 
     temp_code = [

--- a/akshare/fx/fx_quote.py
+++ b/akshare/fx/fx_quote.py
@@ -11,6 +11,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.fx.cons import (
     SHORT_HEADERS,
@@ -28,7 +29,8 @@ def fx_spot_quote() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     payload = {"t": str(int(round(time.time() * 1000)))}
-    res = requests.post(FX_SPOT_URL, data=payload, headers=SHORT_HEADERS)
+    SHORT_HEADERS, timeout = get_headers_and_timeout(locals().get('SHORT_HEADERS', {}), locals().get('timeout', None))
+    res = requests.post(FX_SPOT_URL, data=payload, headers=SHORT_HEADERS, timeout=timeout)
     temp_df = pd.DataFrame(res.json()["records"])
     temp_df = temp_df[["ccyPair", "bidPrc", "askPrc", "midprice", "time"]]
     temp_df.columns = [
@@ -52,7 +54,8 @@ def fx_swap_quote() -> pd.DataFrame:
     :return: pandas.DataFrame
     """
     payload = {"t": str(int(round(time.time() * 1000)))}
-    res = requests.post(FX_SWAP_URL, data=payload, headers=SHORT_HEADERS)
+    SHORT_HEADERS, timeout = get_headers_and_timeout(locals().get('SHORT_HEADERS', {}), locals().get('timeout', None))
+    res = requests.post(FX_SWAP_URL, data=payload, headers=SHORT_HEADERS, timeout=timeout)
     temp_df = pd.DataFrame(res.json()["records"])
     temp_df = temp_df[
         [
@@ -85,7 +88,8 @@ def fx_pair_quote() -> pd.DataFrame:
     :return: pandas.DataFrame
     """
     payload = {"t": str(int(round(time.time() * 1000)))}
-    res = requests.post(FX_PAIR_URL, data=payload, headers=SHORT_HEADERS)
+    SHORT_HEADERS, timeout = get_headers_and_timeout(locals().get('SHORT_HEADERS', {}), locals().get('timeout', None))
+    res = requests.post(FX_PAIR_URL, data=payload, headers=SHORT_HEADERS, timeout=timeout)
     temp_df = pd.DataFrame(res.json()["records"])
     temp_df = temp_df[["ccyPair", "bidPrc", "askPrc", "midprice", "time"]]
     temp_df.columns = [

--- a/akshare/fx/fx_quote_baidu.py
+++ b/akshare/fx/fx_quote_baidu.py
@@ -6,6 +6,7 @@ Desc: 百度股市通-外汇-行情榜单
 https://gushitong.baidu.com/top/foreign-common-%E5%B8%B8%E7%94%A8
 """
 import http.client
+from akshare.request_config_manager import get_headers_and_timeout
 import json
 import urllib
 
@@ -36,7 +37,8 @@ def fx_quote_baidu(symbol: str = "人民币") -> pd.DataFrame:
                 "type": symbol_map[symbol],
                 "finClientType": "pc",
             }
-            conn.request("GET", f"/api/getforeignrank?{urllib.parse.urlencode(params)}")
+            headers, timeout = get_headers_and_timeout(locals().get("headers", {}), locals().get("timeout", None))
+            conn.request("GET", f"/api/getforeignrank?{urllib.parse.urlencode(params)}", headers=headers, timeout=timeout)
             res = conn.getresponse()
             data = res.read()
             data_json = json.loads(data.decode("utf-8"))

--- a/akshare/hf/hf_sp500.py
+++ b/akshare/hf/hf_sp500.py
@@ -8,6 +8,8 @@ long history data for S&P 500 index daily
 http://www.econ.yale.edu/~shiller/data.htm
 """
 import pandas as pd
+import requests
+from io import StringIO
 
 
 def hf_sp_500(year: str = "2017") -> pd.DataFrame:
@@ -19,7 +21,9 @@ def hf_sp_500(year: str = "2017") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://github.com/FutureSharks/financial-data/raw/master/pyfinancialdata/data/stocks/histdata/SPXUSD/DAT_ASCII_SPXUSD_M1_{year}.csv"
-    temp_df = pd.read_table(url, header=None, sep=";")
+    r = requests.get(url)
+    r.raise_for_status()
+    temp_df = pd.read_table(StringIO(r.content), header=None, sep=";")
     temp_df.columns = ["date", "open", "high", "low", "close", "price"]
     temp_df['date'] = pd.to_datetime(temp_df['date']).dt.date
     temp_df['open'] = pd.to_numeric(temp_df['open'])
@@ -30,6 +34,6 @@ def hf_sp_500(year: str = "2017") -> pd.DataFrame:
     return temp_df
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     hf_sp_500_df = hf_sp_500(year="2017")
     print(hf_sp_500_df)

--- a/akshare/index/index_cflp.py
+++ b/akshare/index/index_cflp.py
@@ -7,6 +7,7 @@ http://index.0256.cn/expx.htm
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def index_cflp_price(symbol: str = "周指数") -> pd.DataFrame:
@@ -40,7 +41,8 @@ def index_cflp_price(symbol: str = "周指数") -> pd.DataFrame:
         "Referer": "http://index.0256.cn/expx.htm",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
     }
-    r = requests.post(url, data=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(
         [
@@ -88,7 +90,8 @@ def index_cflp_volume(symbol: str = "月指数") -> pd.DataFrame:
         "Referer": "http://index.0256.cn/expx.htm",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
     }
-    r = requests.post(url, data=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(
         [

--- a/akshare/index/index_cni.py
+++ b/akshare/index/index_cni.py
@@ -10,6 +10,7 @@ from io import BytesIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def index_all_cni() -> pd.DataFrame:
@@ -25,7 +26,8 @@ def index_all_cni() -> pd.DataFrame:
         "rows": "2000",
         "pageNum": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["rows"])
     temp_df.columns = [
@@ -97,7 +99,8 @@ def index_hist_cni(symbol: str = "399001", start_date: str = "20230114", end_dat
         "endDate": end_date,
         "frequency": "day",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["data"])
     temp_df.columns = [
@@ -156,7 +159,8 @@ def index_detail_cni(symbol: str = '399005', date: str = '202011') -> pd.DataFra
         'indexcode': symbol,
         'dateStr': '-'.join([date[:4], date[4:]])
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_excel(BytesIO(r.content))
     temp_df['样本代码'] = temp_df['样本代码'].astype(str).str.zfill(6)
     temp_df.columns = [
@@ -193,7 +197,8 @@ def index_detail_hist_cni(symbol: str = '399001', date: str = "") -> pd.DataFram
             'pageNum': '1',
             'rows': '50000',
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['data']['rows'])
         temp_df.columns = [
@@ -223,7 +228,8 @@ def index_detail_hist_cni(symbol: str = '399001', date: str = "") -> pd.DataFram
         params = {
             'indexcode': symbol
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         temp_df = pd.read_excel(BytesIO(r.content))
     temp_df['样本代码'] = temp_df['样本代码'].astype(str).str.zfill(6)
     temp_df.columns = [
@@ -254,7 +260,8 @@ def index_detail_hist_adjust_cni(symbol: str = '399005') -> pd.DataFrame:
     params = {
         'indexcode': symbol
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     try:
         temp_df = pd.read_excel(BytesIO(r.content), engine="openpyxl")
     except zipfile.BadZipFile as e:

--- a/akshare/index/index_cons.py
+++ b/akshare/index/index_cons.py
@@ -11,6 +11,7 @@ from io import BytesIO, StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.utils import demjson
@@ -29,7 +30,8 @@ def index_stock_cons_sina(symbol: str = "000300") -> pd.DataFrame:
         symbol = "hs300"
         url = "https://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getHQNodeStockCountSimple"
         params = {"node": f"{symbol}"}
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         page_num = math.ceil(int(r.json()) / 80) + 1
         temp_df = pd.DataFrame()
         for page in range(1, page_num):
@@ -43,7 +45,8 @@ def index_stock_cons_sina(symbol: str = "000300") -> pd.DataFrame:
                 "symbol": "",
                 "_s_r_a": "init",
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             temp_df = pd.concat(
                 [temp_df, pd.DataFrame(demjson.decode(r.text))], ignore_index=True
             )
@@ -58,7 +61,8 @@ def index_stock_cons_sina(symbol: str = "000300") -> pd.DataFrame:
         "node": f"zhishu_{symbol}",
         "_s_r_a": "setlen",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     return pd.DataFrame(demjson.decode(r.text))
 
 
@@ -70,7 +74,8 @@ def index_stock_info() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://www.joinquant.com/data/dict/indexData"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     index_df = pd.read_html(StringIO(r.text))[0]
     index_df["指数代码"] = index_df["指数代码"].str.split(".", expand=True)[0]
@@ -89,7 +94,8 @@ def index_stock_cons(symbol: str = "399639") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://vip.stock.finance.sina.com.cn/corp/go.php/vII_NewestComponent/indexid/{symbol}.phtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     soup = BeautifulSoup(r.text, "lxml")
     page_num = (
@@ -107,7 +113,8 @@ def index_stock_cons(symbol: str = "399639") -> pd.DataFrame:
     temp_df = pd.DataFrame()
     for page in range(1, int(page_num) + 1):
         url = f"https://vip.stock.finance.sina.com.cn/corp/view/vII_NewestComponent.php?page={page}&indexid={symbol}"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         r.encoding = "gb2312"
         temp_df = pd.concat(
             [temp_df, pd.read_html(StringIO(r.text), header=1)[3]], ignore_index=True
@@ -127,7 +134,8 @@ def index_stock_cons_csindex(symbol: str = "000300") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://csi-web-dev.oss-cn-shanghai-finance-1-pub.aliyuncs.com/static/html/csindex/public/uploads/file/autofile/cons/{symbol}cons.xls"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_excel(BytesIO(r.content))
     temp_df.columns = [
         "日期",
@@ -156,7 +164,8 @@ def index_stock_cons_weight_csindex(symbol: str = "000300") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://csi-web-dev.oss-cn-shanghai-finance-1-pub.aliyuncs.com/static/html/csindex/public/uploads/file/autofile/closeweight/{symbol}closeweight.xls"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_excel(BytesIO(r.content))
     temp_df.columns = [
         "日期",

--- a/akshare/index/index_cx.py
+++ b/akshare/index/index_cx.py
@@ -7,9 +7,10 @@ https://s.ccxe.com.cn/indices/dei
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
-def index_pmi_com_cx() -> pd.DataFrame():
+def index_pmi_com_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-财新中国 PMI-综合 PMI
     https://s.ccxe.com.cn/indices/pmi
@@ -18,7 +19,8 @@ def index_pmi_com_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "com"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "综合PMI", "日期"]
@@ -33,7 +35,7 @@ def index_pmi_com_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_pmi_man_cx() -> pd.DataFrame():
+def index_pmi_man_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-财新中国 PMI-制造业 PMI
     https://s.ccxe.com.cn/indices/pmi
@@ -42,7 +44,8 @@ def index_pmi_man_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "man"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "制造业PMI", "日期"]
@@ -57,7 +60,7 @@ def index_pmi_man_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_pmi_ser_cx() -> pd.DataFrame():
+def index_pmi_ser_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-财新中国 PMI-服务业 PMI
     https://s.ccxe.com.cn/indices/pmi
@@ -66,7 +69,8 @@ def index_pmi_ser_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "ser"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "服务业PMI", "日期"]
@@ -81,7 +85,7 @@ def index_pmi_ser_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_dei_cx() -> pd.DataFrame():
+def index_dei_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-数字经济指数
     https://s.ccxe.com.cn/indices/dei
@@ -90,7 +94,8 @@ def index_dei_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "dei"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "数字经济指数", "日期"]
@@ -105,7 +110,7 @@ def index_dei_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_ii_cx() -> pd.DataFrame():
+def index_ii_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-产业指数
     https://s.ccxe.com.cn/indices/dei
@@ -114,7 +119,8 @@ def index_ii_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "ii"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "产业指数", "日期"]
@@ -129,7 +135,7 @@ def index_ii_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_si_cx() -> pd.DataFrame():
+def index_si_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-溢出指数
     https://s.ccxe.com.cn/indices/dei
@@ -138,7 +144,8 @@ def index_si_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "si"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "溢出指数", "日期"]
@@ -153,7 +160,7 @@ def index_si_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_fi_cx() -> pd.DataFrame():
+def index_fi_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-融合指数
     https://s.ccxe.com.cn/indices/dei
@@ -162,7 +169,8 @@ def index_fi_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "fi"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "融合指数", "日期"]
@@ -177,7 +185,7 @@ def index_fi_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_bi_cx() -> pd.DataFrame():
+def index_bi_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-基础指数
     https://s.ccxe.com.cn/indices/dei
@@ -186,7 +194,8 @@ def index_bi_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "bi"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "基础指数", "日期"]
@@ -201,7 +210,7 @@ def index_bi_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_nei_cx() -> pd.DataFrame():
+def index_nei_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-中国新经济指数
     https://s.ccxe.com.cn/indices/nei
@@ -210,7 +219,8 @@ def index_nei_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "nei"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "中国新经济指数", "日期"]
@@ -225,7 +235,7 @@ def index_nei_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_li_cx() -> pd.DataFrame():
+def index_li_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-劳动力投入指数
     https://s.ccxe.com.cn/indices/nei
@@ -234,7 +244,8 @@ def index_li_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "li"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "劳动力投入指数", "日期"]
@@ -249,7 +260,7 @@ def index_li_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_ci_cx() -> pd.DataFrame():
+def index_ci_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-资本投入指数
     https://s.ccxe.com.cn/indices/nei
@@ -258,7 +269,8 @@ def index_ci_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "ci"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "资本投入指数", "日期"]
@@ -273,7 +285,7 @@ def index_ci_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_ti_cx() -> pd.DataFrame():
+def index_ti_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-科技投入指数
     https://s.ccxe.com.cn/indices/nei
@@ -282,7 +294,8 @@ def index_ti_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "ti"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "科技投入指数", "日期"]
@@ -297,7 +310,7 @@ def index_ti_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_neaw_cx() -> pd.DataFrame():
+def index_neaw_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-新经济行业入职平均工资水平
     https://s.ccxe.com.cn/indices/nei
@@ -306,7 +319,8 @@ def index_neaw_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "neaw"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "新经济行业入职平均工资水平", "日期"]
@@ -321,7 +335,7 @@ def index_neaw_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_awpr_cx() -> pd.DataFrame():
+def index_awpr_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-新经济入职工资溢价水平
     https://s.ccxe.com.cn/indices/nei
@@ -330,7 +344,8 @@ def index_awpr_cx() -> pd.DataFrame():
     """
     url = "https://s.ccxe.com.cn/api/index/pro/cxIndexTrendInfo"
     params = {"type": "awpr"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "新经济入职工资溢价水平", "日期"]
@@ -345,7 +360,7 @@ def index_awpr_cx() -> pd.DataFrame():
     return temp_df
 
 
-def index_cci_cx() -> pd.DataFrame():
+def index_cci_cx() -> pd.DataFrame:
     """
     财新数据-指数报告-大宗商品指数
     https://s.ccxe.com.cn/indices/cci
@@ -358,7 +373,8 @@ def index_cci_cx() -> pd.DataFrame():
         "code": "1000050",
         "month": "-1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["变化值", "大宗商品指数", "日期"]

--- a/akshare/index/index_drewry.py
+++ b/akshare/index/index_drewry.py
@@ -8,6 +8,7 @@ https://infogram.com/world-container-index-1h17493095xl4zj
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.utils import demjson
@@ -33,7 +34,8 @@ def drewry_wci_index(symbol: str = "composite") -> pd.DataFrame:
         "rotterdam-new york": 7,
     }
     url = "https://infogram.com/world-container-index-1h17493095xl4zj"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     data_text = soup.find_all("script")[-4].string.strip("window.infographicData=")[:-1]
     data_json = demjson.decode(data_text)

--- a/akshare/index/index_eri.py
+++ b/akshare/index/index_eri.py
@@ -7,6 +7,7 @@ https://zs.zjpwq.net/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def index_eri(symbol: str = "月度") -> pd.DataFrame:
@@ -34,14 +35,16 @@ def index_eri(symbol: str = "月度") -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     index_value = temp_df["indexValue"].tolist()
     index_time = [item["stage"]["publishTime"] for item in data_json["data"]]
     big_df = pd.DataFrame([index_time, index_value], index=["日期", "交易指数"]).T
     url = "https://zs.zjpwq.net/pwq-index-webapi/dataStatistics"
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     big_df["成交量"] = temp_df["totalQuantity"].tolist()

--- a/akshare/index/index_fear_greed_funddb.py
+++ b/akshare/index/index_fear_greed_funddb.py
@@ -9,6 +9,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -48,7 +49,8 @@ def index_fear_greed_funddb(symbol: str = "上证指数") -> pd.DataFrame:
         "version": "2.4.5",
         "act_time": 1697623588394,
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     js_code = py_mini_racer.MiniRacer()
     js_content = _get_file_content_ths("cninfo.js")

--- a/akshare/index/index_hog.py
+++ b/akshare/index/index_hog.py
@@ -8,6 +8,7 @@ https://hqb.nxin.com/pigindex/index.shtml
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def index_hog_spot_price() -> pd.DataFrame:
@@ -19,7 +20,8 @@ def index_hog_spot_price() -> pd.DataFrame:
     """
     url = "https://hqb.nxin.com/pigindex/getPigIndexChart.shtml"
     params = {"regionId": "0"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = [

--- a/akshare/index/index_investing.py
+++ b/akshare/index/index_investing.py
@@ -9,6 +9,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.index.cons import short_headers
@@ -29,7 +30,8 @@ def _get_global_index_area_name_code() -> dict:
         "additionalIndices": "on",
         "otherIndices": "on",
     }
-    r = requests.get(url, params=params, headers=short_headers)
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=short_headers, timeout=timeout)
     data_text = r.text
     soup = BeautifulSoup(data_text, "lxml")
     name_url_option_list = soup.find_all("option")[1:]
@@ -59,7 +61,8 @@ def _get_global_country_name_url() -> dict:
     :rtype: dict
     """
     url = "https://cn.investing.com/indices/"
-    res = requests.post(url, headers=short_headers)
+    short_headers, timeout = get_headers_and_timeout(locals().get('short_headers', {}), locals().get('timeout', None))
+    res = requests.post(url, headers=short_headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     name_url_option_list = soup.find(
         "select", attrs={"name": "country"}
@@ -85,7 +88,8 @@ def index_investing_global_area_index_name_code(area: str = "中国") -> dict:
     pd.set_option("mode.chained_assignment", None)
     name_url_dict = _get_global_country_name_url()
     url = f"https://cn.investing.com{name_url_dict[area]}?&majorIndices=on&primarySectors=on&additionalIndices=on&otherIndices=on"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     code_list = [
         item["data-id"]
@@ -114,7 +118,8 @@ def index_investing_global_area_index_name_url(area: str = "中国") -> dict:
     pd.set_option("mode.chained_assignment", None)
     name_url_dict = _get_global_country_name_url()
     url = f"https://cn.investing.com{name_url_dict[area]}?&majorIndices=on&primarySectors=on&additionalIndices=on&otherIndices=on"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     code_list = [
         item.find("a")["href"]
@@ -181,9 +186,11 @@ def index_investing_global(
         "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NjM2NjQ1NzUsImp0aSI6IjIyODA4MDM5MSIsImlhdCI6MTY2MzY2MDk3NSwiaXNzIjoiaW52ZXN0aW5nLmNvbSIsInVzZXJfaWQiOjIyODA4MDM5MSwicHJpbWFyeV9kb21haW5faWQiOiIxIiwiQXV0aG5TeXN0ZW1Ub2tlbiI6IiIsIkF1dGhuU2Vzc2lvblRva2VuIjoiIiwiRGV2aWNlVG9rZW4iOiIiLCJVYXBpVG9rZW4iOiJObmclMkJmMlJyUHpjeWRtdHRaell5TW1JN1pUNWliV1prTURJMVB6czlNeVUySWpVN1lEYzNjV1ZxYWlSZ1kyVjVNamRsWWpRMFptWTFQMkk4TnpCdlBEWXlQbVJrWXo4M01tQnJaMmN3TW1aaU1HVm9ZbWRtWmpBNU5UWTdhRE0lMkJOalUxTW1Cdk56VmxPbW93WUR4bGJUSWdaWGswY0daM05XZGlNamQyYnlnMk9UNSUyRlpEUSUyRllESm1hMjluTURJeFlqRmxQV0l3Wmpjd1pUVXhPenN6S3paOSIsIkF1dGhuSWQiOiIiLCJJc0RvdWJsZUVuY3J5cHRlZCI6ZmFsc2UsIkRldmljZUlkIjoiIiwiUmVmcmVzaEV4cGlyZWRBdCI6MTY2NjE4MDk3NX0.uRLTP1IG3696uxHm3Qq0D8z4o3nfsD3CaIS9cZGjsV0",
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     df_data = pd.DataFrame(data_json["data"])
     df_data.columns = [

--- a/akshare/index/index_kq_fz.py
+++ b/akshare/index/index_kq_fz.py
@@ -7,6 +7,7 @@ http://www.kqindex.cn/flzs/jiage
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -33,7 +34,8 @@ def index_kq_fz(symbol: str = "价格指数") -> pd.DataFrame:
         "pageindex": "1",
         "_": "1619871781413",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json["page"]
     big_df = pd.DataFrame()
@@ -46,7 +48,8 @@ def index_kq_fz(symbol: str = "价格指数") -> pd.DataFrame:
             "pageindex": page,
             "_": "1619871781413",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/index/index_kq_ss.py
+++ b/akshare/index/index_kq_ss.py
@@ -7,6 +7,7 @@ http://ss.kqindex.cn:9559/rinder_web_kqsszs/index/index_page.do
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def index_kq_fashion(symbol: str = "时尚创意指数") -> pd.DataFrame:
@@ -39,7 +40,8 @@ def index_kq_fashion(symbol: str = "时尚创意指数") -> pd.DataFrame:
         "时尚评价指数": "04",
     }
     params = {"structCode": symbol_map[symbol]}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.rename(

--- a/akshare/index/index_option_qvix.py
+++ b/akshare/index/index_option_qvix.py
@@ -8,6 +8,9 @@ http://1.optbbs.com/s/vix.shtml?50ETF
 http://1.optbbs.com/s/vix.shtml?300ETF
 """
 import pandas as pd
+import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 
 
 def index_option_50etf_qvix() -> pd.DataFrame:
@@ -18,7 +21,10 @@ def index_option_50etf_qvix() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://1.optbbs.com/d/csv/d/k.csv"
-    temp_df = pd.read_csv(url).iloc[:, :5]
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    res.raise_for_status()
+    temp_df = pd.read_csv(BytesIO(res.content)).iloc[:, :5]
     temp_df.columns = [
         "date",
         "open",
@@ -42,7 +48,10 @@ def index_option_50etf_min_qvix() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://1.optbbs.com/d/csv/d/vix50.csv"
-    temp_df = pd.read_csv(url).iloc[:, :2]
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    res.raise_for_status()
+    temp_df = pd.read_csv(BytesIO(res.content)).iloc[:, :2]
     temp_df.columns = [
         "time",
         "qvix",
@@ -59,7 +68,10 @@ def index_option_300etf_qvix() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://1.optbbs.com/d/csv/d/k.csv"
-    temp_df = pd.read_csv(url).iloc[:, [0, 9, 10, 11, 12]]
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    res.raise_for_status()
+    temp_df = pd.read_csv(BytesIO(res.content)).iloc[:, [0, 9, 10, 11, 12]]
     temp_df.columns = [
         "date",
         "open",
@@ -83,7 +95,10 @@ def index_option_300etf_min_qvix() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "http://1.optbbs.com/d/csv/d/vix300.csv"
-    temp_df = pd.read_csv(url).iloc[:, :2]
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    res.raise_for_status()
+    temp_df = pd.read_csv(BytesIO(res.content)).iloc[:, :2]
     temp_df.columns = [
         "time",
         "qvix",

--- a/akshare/index/index_research_fund_sw.py
+++ b/akshare/index/index_research_fund_sw.py
@@ -8,6 +8,7 @@ https://www.swsresearch.com/institute_sw/allIndex/releasedIndex
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.cons import headers
 
@@ -30,7 +31,8 @@ def index_realtime_fund_sw(symbol: str = "基础一级") -> pd.DataFrame:
         "rule": "",
         "indexType": 1,
     }
-    r = requests.post(url, json=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["list"])
     temp_df.rename(
@@ -76,7 +78,8 @@ def index_hist_fund_sw(symbol: str = "807200", period: str = "day") -> pd.DataFr
     }
     url = "https://www.swsresearch.com/insWechatSw/fundIndex/getFundKChartData"
     payload = {"swIndexCode": symbol, "type": period_map[period]}
-    r = requests.post(url, json=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.rename(

--- a/akshare/index/index_research_sw.py
+++ b/akshare/index/index_research_sw.py
@@ -10,6 +10,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -39,7 +40,8 @@ def index_hist_sw(symbol: str = "801030", period: str = "day") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.rename(
@@ -97,7 +99,8 @@ def index_min_sw(symbol: str = "801001") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.rename(
@@ -139,7 +142,8 @@ def index_component_sw(symbol: str = "801001") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["results"])
     temp_df.reset_index(inplace=True)
@@ -190,7 +194,8 @@ def __index_realtime_sw(symbol: str = "大类风格指数") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.post(url, json=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["list"])
     temp_df.rename(
@@ -236,7 +241,8 @@ def index_realtime_sw(symbol: str = "二级行业") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_num = data_json["data"]["count"]
     total_page = math.ceil(total_num / 50)
@@ -244,7 +250,8 @@ def index_realtime_sw(symbol: str = "二级行业") -> pd.DataFrame:
     tqdm = get_tqdm()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["results"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -313,7 +320,8 @@ def index_analysis_daily_sw(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_num = data_json["data"]["count"]
     total_page = math.ceil(total_num / 50)
@@ -321,7 +329,8 @@ def index_analysis_daily_sw(
     tqdm = get_tqdm()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["results"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -375,7 +384,8 @@ def index_analysis_week_month_sw(symbol: str = "month") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["bargaindate"] = pd.to_datetime(
@@ -413,7 +423,8 @@ def index_analysis_weekly_sw(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_num = data_json["data"]["count"]
     total_page = math.ceil(total_num / 50)
@@ -421,7 +432,8 @@ def index_analysis_weekly_sw(
     tqdm = get_tqdm()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["results"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -488,7 +500,8 @@ def index_analysis_monthly_sw(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/114.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_num = data_json["data"]["count"]
     total_page = math.ceil(total_num / 50)
@@ -496,7 +509,8 @@ def index_analysis_monthly_sw(
     tqdm = get_tqdm()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["results"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/index/index_spot.py
+++ b/akshare/index/index_spot.py
@@ -7,6 +7,7 @@ http://finance.sina.com.cn/futuremarket/spotprice.shtml#titlePos_0
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def spot_goods(symbol: str = "波罗的海干散货指数") -> pd.DataFrame:
@@ -25,7 +26,8 @@ def spot_goods(symbol: str = "波罗的海干散货指数") -> pd.DataFrame:
         "澳大利亚粉矿价格": "PB",
     }
     params = {"symbol": symbol_url_dict[symbol], "table": "0"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     r.encoding = "gbk"
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"]["data"])

--- a/akshare/index/index_stock_hk.py
+++ b/akshare/index/index_stock_hk.py
@@ -12,6 +12,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from functools import lru_cache
@@ -40,8 +41,11 @@ def get_hk_index_page_count() -> int:
     :return: 需要抓取的指数的总页数
     :rtype: int
     """
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
-        "https://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getNameCount?node=zs_hk"
+        "https://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getNameCount?node=zs_hk",
+        headers=headers,
+        timeout=timeout
     )
     page_count = int(re.findall(re.compile(r"\d+"), res.text)[0]) / 80
     if isinstance(page_count, int):
@@ -65,7 +69,8 @@ def stock_hk_index_spot_sina() -> pd.DataFrame:
         "hkSSE180GV,hkSSE380,hkSSE50,hkSSECEQT,hkSSECOMP,hkSSEDIV,hkSSEITOP,hkSSEMCAP,hkSSEMEGA,hkVHSI"
     )
     headers = {"Referer": "https://vip.stock.finance.sina.com.cn/"}
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     data_list = [
         item.split('"')[1].split(",")
@@ -128,7 +133,8 @@ def stock_hk_index_daily_sina(symbol: str = "CES100") -> pd.DataFrame:
     """
     url = f"https://finance.sina.com.cn/stock/hkstock/{symbol}/klc_kl.js"
     params = {"d": "2023_5_01"}
-    res = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, params=params, headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)
     dict_list = js_code.call(
@@ -167,7 +173,8 @@ def stock_hk_index_spot_em() -> pd.DataFrame:
         "f26,f22,f33,f11,f62,f128,f136,f115,f152",
         "_": "1683800547682",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)
@@ -265,7 +272,8 @@ def stock_hk_index_daily_em(symbol: str = "HSTECF2L") -> pd.DataFrame:
         "ut": "f057cbcbce2a86e2866ab8877db1d059",
         "forcect": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])
     temp_df.columns = [

--- a/akshare/index/index_stock_us_sina.py
+++ b/akshare/index/index_stock_us_sina.py
@@ -8,6 +8,7 @@ https://stock.finance.sina.com.cn/usstock/quotes/.IXIC.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.stock.cons import (
@@ -25,7 +26,8 @@ def index_us_stock_sina(symbol: str = ".INX") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://finance.sina.com.cn/staticdata/us/{symbol}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(zh_js_decode)
     dict_list = js_code.call("d", r.text.split("=")[1].split(";")[0].replace('"', ""))

--- a/akshare/index/index_stock_zh.py
+++ b/akshare/index/index_stock_zh.py
@@ -11,6 +11,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.index.cons import (
@@ -45,7 +46,8 @@ def get_zh_index_page_count() -> int:
     :return: 需要抓取的指数的总页数
     :rtype: int
     """
-    res = requests.get(zh_sina_index_stock_count_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(zh_sina_index_stock_count_url, headers=headers, timeout=timeout)
     page_count = int(re.findall(re.compile(r"\d+"), res.text)[0]) / 80
     if isinstance(page_count, int):
         return page_count
@@ -67,7 +69,8 @@ def stock_zh_index_spot_sina() -> pd.DataFrame:
     tqdm = get_tqdm()
     for page in tqdm(range(1, page_count + 1), leave=False):
         zh_sina_stock_payload_copy.update({"page": page})
-        res = requests.get(zh_sina_index_stock_url, params=zh_sina_stock_payload_copy)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_index_stock_url, params=zh_sina_stock_payload_copy, headers=headers, timeout=timeout)
         data_json = demjson.decode(res.text)
         big_df = pd.concat([big_df, pd.DataFrame(data_json)], ignore_index=True)
     big_df = big_df.map(_replace_comma)
@@ -154,7 +157,8 @@ def stock_zh_index_spot_em(symbol: str = "上证系列指数") -> pd.DataFrame:
         'fields': 'f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f12,f13,f14,f15,f16,f17,f18,f20,f21,f23,f24,f25,f26,f22,f33,f11,f62,f128,f136,f115,f152',
         '_': '1704327268532',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['data']['diff'])
     temp_df.reset_index(inplace=True)
@@ -215,7 +219,8 @@ def stock_zh_index_daily(symbol: str = "sh000922") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     params = {"d": "2020_2_4"}
-    res = requests.get(zh_sina_index_stock_hist_url.format(symbol), params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(zh_sina_index_stock_hist_url.format(symbol), params=params, headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)
     dict_list = js_code.call(
@@ -247,7 +252,8 @@ def get_tx_start_year(symbol: str = "sh000919") -> pd.DataFrame:
         "_var": "trend_qfq",
         "r": "0.3506048543943414",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     if not demjson.decode(data_text[data_text.find("={") + 1:])["data"]:
         url = "https://proxy.finance.qq.com/ifzqgtimg/appstock/app/newfqkline/get"
@@ -256,7 +262,8 @@ def get_tx_start_year(symbol: str = "sh000919") -> pd.DataFrame:
             "param": f"{symbol},day,,,320,qfq",
             "r": "0.751892490072597",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         start_date = demjson.decode(data_text[data_text.find("={") + 1:])["data"][
             symbol
@@ -289,7 +296,8 @@ def stock_zh_index_daily_tx(symbol: str = "sz980017") -> pd.DataFrame:
             "param": f"{symbol},day,{year}-01-01,{year + 1}-12-31,640,qfq",
             "r": "0.8205512681390605",
         }
-        res = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(url, params=params, headers=headers, timeout=timeout)
         text = res.text
         try:
             inner_temp_df = pd.DataFrame(
@@ -354,7 +362,8 @@ def stock_zh_index_daily_em(
         "end": end_date,
         "_": "1596700547039",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{"): -2])
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])

--- a/akshare/index/index_stock_zh_csindex.py
+++ b/akshare/index/index_stock_zh_csindex.py
@@ -11,6 +11,8 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 
 
 def __get_current_timestamp_ms() -> int:
@@ -221,7 +223,8 @@ def stock_zh_index_hist_csindex(
         "startDate": start_date,
         "endDate": end_date,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = [
@@ -266,7 +269,10 @@ def stock_zh_index_value_csindex(symbol: str = "H30374") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://csi-web-dev.oss-cn-shanghai-finance-1-pub.aliyuncs.com/static/html/csindex/public/uploads/file/autofile/indicator/{symbol}indicator.xls"
-    temp_df = pd.read_excel(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    res.raise_for_status()
+    temp_df = pd.read_excel(BytesIO(res.content))
     temp_df.columns = [
         "日期",
         "指数代码",
@@ -314,7 +320,8 @@ def index_value_name_funddb() -> pd.DataFrame:
         "act_time": str(get_current_timestamp_ms_str)
     }
     payload.update(encode_params)
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["right_list"])
     temp_df.columns = [
@@ -422,7 +429,8 @@ def index_value_hist_funddb(
         "act_time": str(get_current_timestamp_ms_str)
     }
     payload.update(encode_params)
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     temp_df = pd.DataFrame(

--- a/akshare/index/index_sugar.py
+++ b/akshare/index/index_sugar.py
@@ -6,6 +6,7 @@ Desc: 沐甜科技数据中心-中国食糖指数
 https://www.msweet.com.cn/mtkj/sjzx13/index.html
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -21,7 +22,8 @@ def index_sugar_msweet() -> pd.DataFrame:
         "struts.portlet.action": "/portlet/price!getSTZSJson.action",
         "moduleId": "cb752447cfe24b44b18c7a7e9abab048",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.concat(
         [pd.DataFrame(data_json["category"]), pd.DataFrame(data_json["data"])], axis=1
@@ -43,7 +45,8 @@ def index_inner_quote_sugar_msweet() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://www.msweet.com.cn/datacenterapply/datacenter/json/JinKongTang.json"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.concat(
         [pd.DataFrame(data_json["category"]), pd.DataFrame(data_json["data"])], axis=1
@@ -88,7 +91,8 @@ def index_outer_quote_sugar_msweet() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://www.msweet.com.cn/datacenterapply/datacenter/json/Jkpewlr.json"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.concat(
         [pd.DataFrame(data_json["category"]), pd.DataFrame(data_json["data"])], axis=1

--- a/akshare/index/index_sw.py
+++ b/akshare/index/index_sw.py
@@ -8,6 +8,8 @@ https://legulegu.com/stockdata/index-composition?industryCode=851921.SI
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 from bs4 import BeautifulSoup
 
 
@@ -19,7 +21,8 @@ def sw_index_first_info() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://legulegu.com/stockdata/sw-industry-overview"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     code_raw = soup.find("div", attrs={"id": "level1Items"}).find_all(
         "div", attrs={"class": "lg-industries-item-chinese-title"}
@@ -75,7 +78,8 @@ def sw_index_second_info() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://legulegu.com/stockdata/sw-industry-overview"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     code_raw = soup.find("div", attrs={"id": "level2Items"}).find_all(
         "div", attrs={"class": "lg-industries-item-chinese-title"}
@@ -131,7 +135,8 @@ def sw_index_third_info() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://legulegu.com/stockdata/sw-industry-overview"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     code_raw = soup.find("div", attrs={"id": "level3Items"}).find_all(
         "div", attrs={"class": "lg-industries-item-chinese-title"}
@@ -189,7 +194,10 @@ def sw_index_third_cons(symbol: str = "801120.SI") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://legulegu.com/stockdata/index-composition?industryCode={symbol}"
-    temp_df = pd.read_html(url)[0]
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    res.raise_for_status()
+    temp_df = pd.read_html(BytesIO(res.content))[0]
     temp_df.columns = [
         "序号",
         "股票代码",

--- a/akshare/index/index_yw.py
+++ b/akshare/index/index_yw.py
@@ -7,6 +7,7 @@ https://www.ywindex.com/Home/Product/index/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -25,7 +26,8 @@ def index_yw(symbol: str = "月景气指数") -> pd.DataFrame:
         "月景气指数": 5,
     }
     url = "http://www.ywindex.com/Home/Product/index/"
-    res = requests.get(url, verify=False)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, verify=False, headers=headers, timeout=timeout)
     soup = BeautifulSoup(res.text, "lxml")
     table_name = (
         soup.find_all(attrs={"class": "tablex"})[name_num_dict[symbol]]

--- a/akshare/index/index_zh_em.py
+++ b/akshare/index/index_zh_em.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 @lru_cache()
@@ -33,7 +34,8 @@ def index_code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -54,7 +56,8 @@ def index_code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -74,7 +77,8 @@ def index_code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -135,7 +139,8 @@ def index_zh_a_hist(
             "end": "20500000",
             "_": "1623766962675",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         if data_json["data"] is None:
             params = {
@@ -149,7 +154,8 @@ def index_zh_a_hist(
                 "end": "20500000",
                 "_": "1623766962675",
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             if data_json["data"] is None:
                 params = {
@@ -163,7 +169,8 @@ def index_zh_a_hist(
                     "end": "20500000",
                     "_": "1623766962675",
                 }
-                r = requests.get(url, params=params)
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(url, params=params, headers=headers, timeout=timeout)
                 data_json = r.json()
                 if data_json["data"] is None:
                     params = {
@@ -177,7 +184,8 @@ def index_zh_a_hist(
                         "end": "20500000",
                         "_": "1623766962675",
                     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     try:
         temp_df = pd.DataFrame(
@@ -196,7 +204,8 @@ def index_zh_a_hist(
             "end": "20500000",
             "_": "1623766962675",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]
@@ -273,7 +282,8 @@ def index_zh_a_hist_min_em(
                 "secid": f"1.{symbol}",
                 "_": "1623766962675",
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             if data_json["data"] is None:
                 params = {
@@ -285,7 +295,8 @@ def index_zh_a_hist_min_em(
                     "secid": f"0.{symbol}",
                     "_": "1623766962675",
                 }
-                r = requests.get(url, params=params)
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(url, params=params, headers=headers, timeout=timeout)
                 data_json = r.json()
                 if data_json["data"] is None:
                     params = {
@@ -297,7 +308,8 @@ def index_zh_a_hist_min_em(
                         "secid": f"47.{symbol}",
                         "_": "1623766962675",
                     }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["trends"]]
@@ -350,7 +362,8 @@ def index_zh_a_hist_min_em(
                 "end": "20500000",
                 "_": "1630930917857",
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             if data_json["data"] is None:
                 params = {
@@ -364,7 +377,8 @@ def index_zh_a_hist_min_em(
                     "end": "20500000",
                     "_": "1630930917857",
                 }
-                r = requests.get(url, params=params)
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(url, params=params, headers=headers, timeout=timeout)
                 data_json = r.json()
                 if data_json["data"] is None:
                     params = {
@@ -378,7 +392,8 @@ def index_zh_a_hist_min_em(
                         "end": "20500000",
                         "_": "1630930917857",
                     }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]

--- a/akshare/interest_rate/interbank_rate_em.py
+++ b/akshare/interest_rate/interbank_rate_em.py
@@ -6,6 +6,7 @@ Desc: 东方财富网-经济数据-银行间拆借利率
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -83,7 +84,8 @@ def rate_interbank(
         "pageNum": "1",
         "_": "1653376974939",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()

--- a/akshare/movie/artist_yien.py
+++ b/akshare/movie/artist_yien.py
@@ -13,6 +13,7 @@ import os
 
 import pandas as pd  # type: ignore
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer  # type: ignore
 
 
@@ -76,7 +77,8 @@ def business_value_artist() -> pd.DataFrame:
         "PageSize": "100",
         "MethodName": "Data_GetList_Star",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])
@@ -101,7 +103,8 @@ def online_value_artist() -> pd.DataFrame:
         "PageSize": 100,
         "MethodName": "Data_GetList_Star",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])

--- a/akshare/movie/movie_yien.py
+++ b/akshare/movie/movie_yien.py
@@ -11,6 +11,7 @@ import os
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 
@@ -88,7 +89,8 @@ def movie_boxoffice_realtime() -> pd.DataFrame:
         "tdate": f"{today[:4]}-{today[4:6]}-{today[6:]}",
         "MethodName": "BoxOffice_GetHourBoxOffice",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table1"])
@@ -115,7 +117,8 @@ def movie_boxoffice_daily(date: str = "20240219") -> pd.DataFrame:
         "edate": f"{last_date[:4]}-{last_date[4:6]}-{last_date[6:]}",
         "MethodName": "BoxOffice_GetDayBoxOffice",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])
@@ -158,7 +161,8 @@ def movie_boxoffice_weekly(date: str = "20240218") -> pd.DataFrame:
         "sdate": get_current_week(date=date).strftime("%Y-%m-%d"),
         "MethodName": "BoxOffice_GetWeekInfoData",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])
     temp_df.columns = [
@@ -202,7 +206,8 @@ def movie_boxoffice_monthly(date: str = "20240218") -> pd.DataFrame:
         "startTime": f"{date[:4]}-{date[4:6]}-01",
         "MethodName": "BoxOffice_GetMonthBox",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])
@@ -240,7 +245,8 @@ def movie_boxoffice_yearly(date: str = "20240218") -> pd.DataFrame:
         "year": f"{date[:4]}",
         "MethodName": "BoxOffice_GetYearInfoData",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])
@@ -277,7 +283,8 @@ def movie_boxoffice_yearly_first_week(date: str = "20201018") -> pd.DataFrame:
         "year": f"{date[:4]}",
         "MethodName": "BoxOffice_getYearInfo_fData",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])
@@ -320,7 +327,8 @@ def movie_boxoffice_cinema_daily(date: str = "20240219") -> pd.DataFrame:
         "date": date,
         "MethodName": "BoxOffice_GetCinemaDayBoxOffice",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])
@@ -363,7 +371,8 @@ def movie_boxoffice_cinema_weekly(date: str = "20240219") -> pd.DataFrame:
         "rowNum2": "100",
         "MethodName": "BoxOffice_GetCinemaWeekBoxOffice",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])

--- a/akshare/movie/video_yien.py
+++ b/akshare/movie/video_yien.py
@@ -13,6 +13,7 @@ import os
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 
@@ -70,7 +71,8 @@ def video_tv() -> pd.DataFrame:
     """
     url = "https://www.endata.com.cn/API/GetData.ashx"
     payload = {"tvType": 2, "MethodName": "BoxOffice_GetTvData_PlayIndexRank"}
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])
@@ -90,7 +92,8 @@ def video_variety_show() -> pd.DataFrame:
     """
     url = "https://www.endata.com.cn/API/GetData.ashx"
     payload = {"tvType": 8, "MethodName": "BoxOffice_GetTvData_PlayIndexRank"}
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     data_json = json.loads(decrypt(r.text))
     temp_df = pd.DataFrame(data_json["Data"]["Table"])

--- a/akshare/news/news_baidu.py
+++ b/akshare/news/news_baidu.py
@@ -12,6 +12,8 @@ from urllib.parse import urlencode
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def news_economic_baidu(date: str = "20240327") -> pd.DataFrame:
@@ -35,7 +37,8 @@ def news_economic_baidu(date: str = "20240327") -> pd.DataFrame:
         # "pn": "0",
         "finClientType": "pc",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     for item in data_json["Result"]:
@@ -96,7 +99,8 @@ def news_trade_notify_suspend_baidu(date: str = "20220513") -> pd.DataFrame:
         "market": "",
         "cate": "notify_suspend",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     for item in data_json["Result"]:
@@ -145,7 +149,8 @@ def news_trade_notify_dividend_baidu(date: str = "20220513") -> pd.DataFrame:
     """
     start_date = "-".join([date[:4], date[4:6], date[6:]])
     end_date = "-".join([date[:4], date[4:6], date[6:]])
-    conn = http.client.HTTPSConnection("finance.pae.baidu.com")
+    headers, timeout = get_headers_and_timeout(locals().get("headers", {}), locals().get("timeout", None))
+    conn = http.client.HTTPSConnection("finance.pae.baidu.com", timeout=timeout)
     params = {
         "start_date": start_date,
         "end_date": end_date,
@@ -154,7 +159,7 @@ def news_trade_notify_dividend_baidu(date: str = "20220513") -> pd.DataFrame:
     }
     query_string = urlencode(params)
     url = "/api/financecalendar" + "?" + query_string
-    conn.request(method="GET", url=url)
+    conn.request(method="GET", url=url, headers=headers)
     r = conn.getresponse()
     data = r.read()
     data_json = json.loads(data)
@@ -223,7 +228,8 @@ def news_report_time_baidu(date: str = "20220514") -> pd.DataFrame:
         "cate": "report_time",
         "finClientType": "pc",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     for item in data_json["Result"]:

--- a/akshare/news/news_cctv.py
+++ b/akshare/news/news_cctv.py
@@ -9,6 +9,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -24,7 +25,8 @@ def news_cctv(date: str = "20130308") -> pd.DataFrame:
     """
     if int(date) <= int("20130708"):
         url = f"http://cctv.cntv.cn/lm/xinwenlianbo/{date}.shtml"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         r.encoding = "gbk"
         raw_list = re.findall(r"title_array_01\((.*)", r.text)
         page_url = [
@@ -47,7 +49,8 @@ def news_cctv(date: str = "20130308") -> pd.DataFrame:
         }
         for page in tqdm(page_url, leave=False):
             try:
-                r = requests.get(page, headers=headers)
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(page, headers=headers, timeout=timeout)
                 r.encoding = "utf-8"
                 soup = BeautifulSoup(r.text, "lxml")
                 title = soup.find("h3").text
@@ -73,7 +76,8 @@ def news_cctv(date: str = "20130308") -> pd.DataFrame:
 
     elif int(date) < int("20160203"):
         url = f"http://cctv.cntv.cn/lm/xinwenlianbo/{date}.shtml"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         r.encoding = "utf-8"
         soup = BeautifulSoup(r.text, "lxml")
         page_url = [
@@ -98,7 +102,8 @@ def news_cctv(date: str = "20130308") -> pd.DataFrame:
         }
         for page in tqdm(page_url, leave=False):
             try:
-                r = requests.get(page, headers=headers)
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(page, headers=headers, timeout=timeout)
                 r.encoding = "utf-8"
                 soup = BeautifulSoup(r.text, "lxml")
                 title = soup.find("h3").text
@@ -123,7 +128,8 @@ def news_cctv(date: str = "20130308") -> pd.DataFrame:
         return temp_df
     elif int(date) > int("20160203"):
         url = f"https://tv.cctv.com/lm/xwlb/day/{date}.shtml"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         r.encoding = "utf-8"
         soup = BeautifulSoup(r.text, "lxml")
         page_url = [item.find("a")["href"] for item in soup.find_all("li")[1:]]
@@ -143,7 +149,8 @@ def news_cctv(date: str = "20130308") -> pd.DataFrame:
         }
         for page in tqdm(page_url, leave=False):
             try:
-                r = requests.get(page, headers=headers)
+                headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+                r = requests.get(page, headers=headers, timeout=timeout)
                 r.encoding = "utf-8"
                 soup = BeautifulSoup(r.text, "lxml")
                 if soup.find("h3"):

--- a/akshare/news/news_stock.py
+++ b/akshare/news/news_stock.py
@@ -9,6 +9,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_news_em(symbol: str = "300059") -> pd.DataFrame:
@@ -28,7 +29,8 @@ def stock_news_em(symbol: str = "300059") -> pd.DataFrame:
         + ',"type":["cmsArticleWebOld"],"client":"web","clientType":"web","clientVersion":"curr","param":{"cmsArticleWebOld":{"searchScope":"default","sort":"default","pageIndex":1,"pageSize":100,"preTag":"<em>","postTag":"</em>"}}}',
         "_": "1668256937996",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = json.loads(
         data_text.strip("jQuery3510875346244069884_1668256937995(")[:-1]

--- a/akshare/nlp/nlp_interface.py
+++ b/akshare/nlp/nlp_interface.py
@@ -8,6 +8,7 @@ https://www.ownthink.com/docs/kg/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def nlp_ownthink(word: str = "人工智能", indicator: str = "entity") -> pd.DataFrame:
@@ -25,7 +26,8 @@ def nlp_ownthink(word: str = "人工智能", indicator: str = "entity") -> pd.Da
     payload = {
         "entity": word,
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     if not r.json()["data"]:
         print("Can not find the resource, please type into the correct word")
         return None
@@ -52,7 +54,8 @@ def nlp_answer(question: str = "人工智能") -> str:
     params = {
         'spoken': question
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     json_data = r.json()
     answer = json_data['data']['info']['text']
     return answer

--- a/akshare/option/option_commodity.py
+++ b/akshare/option/option_commodity.py
@@ -20,6 +20,7 @@ from typing import Tuple, Any
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.option.cons import (
     get_calendar,
@@ -58,7 +59,8 @@ def option_dce_daily(
         "day": str(day.day),
         "exportFlag": "excel",
     }
-    res = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.post(url, data=payload, headers=headers, timeout=timeout)
     table_df = pd.read_excel(BytesIO(res.content), header=1)
     another_df = table_df.iloc[
                  table_df[table_df.iloc[:, 0].str.contains("合约")].iloc[-1].name:,
@@ -159,7 +161,8 @@ def option_czce_daily(
     if day > datetime.date(2010, 8, 24):
         url = CZCE_DAILY_OPTION_URL_3.format(day.strftime("%Y"), day.strftime("%Y%m%d"))
         try:
-            r = requests.get(url)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, headers=headers, timeout=timeout)
             f = StringIO(r.text)
             table_df = pd.read_table(f, encoding="utf-8", skiprows=1, sep="|")
             if symbol == "白糖期权":
@@ -242,7 +245,8 @@ def option_shfe_daily(
     if day > datetime.date(2010, 8, 24):
         url = SHFE_OPTION_URL.format(day.strftime("%Y%m%d"))
         try:
-            r = requests.get(url, headers=SHFE_HEADERS)
+            SHFE_HEADERS, timeout = get_headers_and_timeout(locals().get('SHFE_HEADERS', {}), locals().get('timeout', None))
+            r = requests.get(url, headers=SHFE_HEADERS, timeout=timeout)
             json_data = r.json()
             table_df = pd.DataFrame(
                 [
@@ -368,7 +372,8 @@ def option_gfex_daily(symbol: str = "工业硅", trade_date: str = "20230724"):
         "X-Requested-With": "XMLHttpRequest",
         "content-type": "application/x-www-form-urlencoded",
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.rename(
@@ -458,7 +463,8 @@ def option_gfex_vol_daily(symbol: str = "碳酸锂", trade_date: str = "20230724
         "X-Requested-With": "XMLHttpRequest",
         "content-type": "application/x-www-form-urlencoded",
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.rename(

--- a/akshare/option/option_commodity_sina.py
+++ b/akshare/option/option_commodity_sina.py
@@ -7,6 +7,7 @@ https://stock.finance.sina.com.cn/futures/view/optionsDP.php
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.utils import demjson
@@ -24,7 +25,8 @@ def option_commodity_contract_sina(symbol: str = "玉米期权") -> pd.DataFrame
     url = (
         "https://stock.finance.sina.com.cn/futures/view/optionsDP.php/pg_o/dce"
     )
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     url_list = [
         item.find("a")["href"]
@@ -40,7 +42,8 @@ def option_commodity_contract_sina(symbol: str = "玉米期权") -> pd.DataFrame
         key: value for key, value in zip(commodity_list, url_list)
     }
     url = "https://stock.finance.sina.com.cn" + comm_list_dict[symbol]
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     symbol = (
         soup.find(attrs={"id": "option_symbol"})
@@ -74,7 +77,8 @@ def option_commodity_contract_table_sina(
     url = (
         "https://stock.finance.sina.com.cn/futures/view/optionsDP.php/pg_o/dce"
     )
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     url_list = [
         item.find("a")["href"]
@@ -96,7 +100,8 @@ def option_commodity_contract_table_sina(
         "exchange": comm_list_dict[symbol].split("/")[-1],
         "pinzhong": contract,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     up_df = pd.DataFrame(data_json["result"]["data"]["up"])
     down_df = pd.DataFrame(data_json["result"]["data"]["down"])
@@ -149,7 +154,8 @@ def option_commodity_hist_sina(symbol: str = "au2012C392") -> pd.DataFrame:
     """
     url = "https://stock.finance.sina.com.cn/futures/api/jsonp.php/var%20_m2009C30002020_7_17=/FutureOptionAllService.getOptionDayline"
     params = {"symbol": symbol}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("[") : -2])
     temp_df = pd.DataFrame(data_json)

--- a/akshare/option/option_czce.py
+++ b/akshare/option/option_czce.py
@@ -18,6 +18,7 @@ import warnings
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def option_czce_hist(symbol: str = "SR", year: str = "2021") -> pd.DataFrame:
@@ -44,7 +45,8 @@ def option_czce_hist(symbol: str = "SR", year: str = "2021") -> pd.DataFrame:
         return None
     warnings.warn("正在下载中, 请稍等")
     url = f'http://www.czce.com.cn/cn/DFSStaticFiles/Option/2021/OptionDataAllHistory/{symbol}OPTIONS{year}.txt'
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     option_df = pd.read_table(StringIO(r.text), skiprows=1, sep="|", low_memory=False)
     return option_df
 

--- a/akshare/option/option_em.py
+++ b/akshare/option/option_em.py
@@ -8,6 +8,7 @@ https://quote.eastmoney.com/center/qqsc.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def option_current_em() -> pd.DataFrame:
@@ -32,7 +33,8 @@ def option_current_em() -> pd.DataFrame:
         "f23,f24,f25,f22,f28,f11,f62,f128,f136,f115,f152,f133,f108,f163,f161,f162",
         "_": "1606225274063",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)
@@ -125,7 +127,8 @@ def option_current_cffex_em() -> pd.DataFrame:
         "blockName": "callback",
         "_:": "1706689899924",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["list"])
     temp_df.reset_index(inplace=True)

--- a/akshare/option/option_finance.py
+++ b/akshare/option/option_finance.py
@@ -12,6 +12,7 @@ from io import BytesIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.option.cons import (
     SH_OPTION_PAYLOAD,
@@ -46,7 +47,8 @@ def option_finance_sse_underlying(symbol: str = "华夏科创50ETF期权") -> pd
         "华夏科创50ETF期权": SH_OPTION_URL_KC_50,
         "易方达科创50ETF期权": SH_OPTION_URL_KC_50_YFD,
     }
-    r = requests.get(symbol_map[symbol], params=SH_OPTION_PAYLOAD)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(symbol_map[symbol], params=SH_OPTION_PAYLOAD, headers=headers, timeout=timeout)
     data_json = r.json()
     raw_data = pd.DataFrame(data_json["list"])
     raw_data.at[0, 0] = "510300"
@@ -88,9 +90,12 @@ def option_finance_board(
     """
     end_month = end_month[-2:]
     if symbol == "华夏上证50ETF期权":
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         r = requests.get(
             SH_OPTION_URL_KING_50.format(end_month),
             params=SH_OPTION_PAYLOAD_OTHER,
+            headers=headers,
+            timeout=timeout
         )
         data_json = r.json()
         raw_data = pd.DataFrame(data_json["list"])
@@ -103,9 +108,12 @@ def option_finance_board(
         raw_data.columns = ["日期", "合约交易代码", "当前价", "涨跌幅", "前结价", "行权价", "数量"]
         return raw_data
     elif symbol == "华泰柏瑞沪深300ETF期权":
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         r = requests.get(
             SH_OPTION_URL_KING_300.format(end_month),
             params=SH_OPTION_PAYLOAD_OTHER,
+            headers=headers,
+            timeout=timeout
         )
         data_json = r.json()
         raw_data = pd.DataFrame(data_json["list"])
@@ -118,9 +126,12 @@ def option_finance_board(
         raw_data.columns = ["日期", "合约交易代码", "当前价", "涨跌幅", "前结价", "行权价", "数量"]
         return raw_data
     elif symbol == "南方中证500ETF期权":
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         r = requests.get(
             SH_OPTION_URL_KING_500.format(end_month),
             params=SH_OPTION_PAYLOAD_OTHER,
+            headers=headers,
+            timeout=timeout
         )
         data_json = r.json()
         raw_data = pd.DataFrame(data_json["list"])
@@ -133,9 +144,12 @@ def option_finance_board(
         raw_data.columns = ["日期", "合约交易代码", "当前价", "涨跌幅", "前结价", "行权价", "数量"]
         return raw_data
     elif symbol == "华夏科创50ETF期权":
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         r = requests.get(
             SH_OPTION_URL_KC_KING_50.format(end_month),
             params=SH_OPTION_PAYLOAD_OTHER,
+            headers=headers,
+            timeout=timeout
         )
         data_json = r.json()
         raw_data = pd.DataFrame(data_json["list"])
@@ -148,9 +162,12 @@ def option_finance_board(
         raw_data.columns = ["日期", "合约交易代码", "当前价", "涨跌幅", "前结价", "行权价", "数量"]
         return raw_data
     elif symbol == "易方达科创50ETF期权":
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         r = requests.get(
             SH_OPTION_URL_KING_50_YFD.format(end_month),
             params=SH_OPTION_PAYLOAD_OTHER,
+            headers=headers,
+            timeout=timeout
         )
         data_json = r.json()
         raw_data = pd.DataFrame(data_json["list"])
@@ -171,7 +188,8 @@ def option_finance_board(
             "PAGENO": "1",
             "random": "0.10642298535346595",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         page_num = data_json[0]["metadata"]["pagecount"]
         big_df = pd.DataFrame()
@@ -183,7 +201,8 @@ def option_finance_board(
                 "PAGENO": page,
                 "random": "0.10642298535346595",
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json[0]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -208,7 +227,8 @@ def option_finance_board(
         headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
         }
-        r = requests.get(CFFEX_OPTION_URL_300, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(CFFEX_OPTION_URL_300, headers=headers, timeout=timeout)
         raw_df = pd.read_table(BytesIO(r.content), sep=",")
         raw_df["end_month"] = (
             raw_df["instrument"]
@@ -227,7 +247,8 @@ def option_finance_board(
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
         }
         url = "http://www.cffex.com.cn/quote_MO.txt"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         raw_df = pd.read_table(BytesIO(r.content), sep=",")
         raw_df["end_month"] = (
             raw_df["instrument"]
@@ -246,7 +267,8 @@ def option_finance_board(
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
         }
         url = "http://www.cffex.com.cn/quote_HO.txt"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         raw_df = pd.read_table(BytesIO(r.content), sep=",")
         raw_df["end_month"] = (
             raw_df["instrument"]

--- a/akshare/option/option_finance_sina.py
+++ b/akshare/option/option_finance_sina.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Tuple
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.option.option_em import option_current_em
@@ -33,7 +34,8 @@ def option_cffex_sz50_list_sina() -> Dict[str, List[str]]:
     :rtype: dict
     """
     url = "https://stock.finance.sina.com.cn/futures/view/optionsCffexDP.php/ho/cffex"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     symbol = soup.find(attrs={"id": "option_symbol"}).find_all("li")[0].text
     temp_attr = soup.find(attrs={"id": "option_suffix"}).find_all("li")
@@ -50,7 +52,8 @@ def option_cffex_hs300_list_sina() -> Dict[str, List[str]]:
     :rtype: dict
     """
     url = "https://stock.finance.sina.com.cn/futures/view/optionsCffexDP.php"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     symbol = soup.find(attrs={"id": "option_symbol"}).find_all("li")[1].text
     temp_attr = soup.find(attrs={"id": "option_suffix"}).find_all("li")
@@ -66,7 +69,8 @@ def option_cffex_zz1000_list_sina() -> Dict[str, List[str]]:
     :rtype: dict
     """
     url = "https://stock.finance.sina.com.cn/futures/view/optionsCffexDP.php/mo/cffex"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     symbol = soup.find(attrs={"id": "option_symbol"}).find_all("li")[2].text
     temp_attr = soup.find(attrs={"id": "option_suffix"}).find_all("li")
@@ -90,7 +94,8 @@ def option_cffex_sz50_spot_sina(symbol: str = "ho2303") -> pd.DataFrame:
         "exchange": "cffex",
         "pinzhong": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = json.loads(data_text[data_text.find("{") : data_text.rfind("}") + 1])
     option_call_df = pd.DataFrame(
@@ -163,7 +168,8 @@ def option_cffex_hs300_spot_sina(symbol: str = "io2204") -> pd.DataFrame:
         "exchange": "cffex",
         "pinzhong": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = json.loads(data_text[data_text.find("{") : data_text.rfind("}") + 1])
     option_call_df = pd.DataFrame(
@@ -236,7 +242,8 @@ def option_cffex_zz1000_spot_sina(symbol: str = "mo2208") -> pd.DataFrame:
         "exchange": "cffex",
         "pinzhong": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = json.loads(data_text[data_text.find("{") : data_text.rfind("}") + 1])
     option_call_df = pd.DataFrame(
@@ -309,7 +316,8 @@ def option_cffex_sz50_daily_sina(symbol: str = "ho2303P2350") -> pd.DataFrame:
         f"=/FutureOptionAllService.getOptionDayline"
     )
     params = {"symbol": symbol}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_df = pd.DataFrame(
         eval(data_text[data_text.find("[") : data_text.rfind("]") + 1])
@@ -350,7 +358,8 @@ def option_cffex_hs300_daily_sina(symbol: str = "io2202P4350") -> pd.DataFrame:
         f"=/FutureOptionAllService.getOptionDayline"
     )
     params = {"symbol": symbol}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_df = pd.DataFrame(
         eval(data_text[data_text.find("[") : data_text.rfind("]") + 1])
@@ -393,7 +402,8 @@ def option_cffex_zz1000_daily_sina(
         f"=/FutureOptionAllService.getOptionDayline"
     )
     params = {"symbol": symbol}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_df = pd.DataFrame(
         eval(data_text[data_text.find("[") : data_text.rfind("]") + 1])
@@ -432,7 +442,8 @@ def option_sse_list_sina(symbol: str = "50ETF", exchange: str = "null") -> List[
     """
     url = "http://stock.finance.sina.com.cn/futures/api/openapi.php/StockOptionService.getStockName"
     params = {"exchange": f"{exchange}", "cate": f"{symbol}"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     date_list = data_json["result"]["data"]["contractMonth"]
     return ["".join(i.split("-")) for i in date_list][1:]
@@ -458,7 +469,8 @@ def option_sse_expire_day_sina(
         "cate": f"{symbol}",
         "date": f"{trade_date[:4]}-{trade_date[4:]}",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     data = data_json["result"]["data"]
     if int(data["remainderDays"]) < 0:
@@ -468,7 +480,8 @@ def option_sse_expire_day_sina(
             "cate": f"{'XD' + symbol}",
             "date": f"{trade_date[:4]}-{trade_date[4:]}",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         data = data_json["result"]["data"]
     return data["expireDay"], int(data["remainderDays"])
@@ -525,7 +538,8 @@ def option_sse_codes_sina(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/97.0.4692.71 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     data_temp = data_text.replace('"', ",").split(",")
     temp_list = [i[7:] for i in data_temp if i.startswith("CON_OP_")]
@@ -566,7 +580,8 @@ def option_sse_spot_price_sina(symbol: str = "10003720") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/97.0.4692.71 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     data_list = data_text[data_text.find('"') + 1 : data_text.rfind('"')].split(",")
     field_list = [
@@ -641,7 +656,8 @@ def option_sse_underlying_spot_price_sina(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/97.0.4692.71 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     data_list = data_text[data_text.find('"') + 1 : data_text.rfind('"')].split(",")
     field_list = [
@@ -704,7 +720,8 @@ def option_sse_greeks_sina(symbol: str = "10003045") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/97.0.4692.71 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_text = r.text
     data_list = data_text[data_text.find('"') + 1 : data_text.rfind('"')].split(",")
     field_list = [
@@ -756,7 +773,8 @@ def option_sse_minute_sina(symbol: str = "10003720") -> pd.DataFrame:
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/97.0.4692.71 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = data_json["result"]["data"]
     data_df = pd.DataFrame(temp_df)
@@ -799,7 +817,8 @@ def option_sse_daily_sina(symbol: str = "10003889") -> pd.DataFrame:
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/97.0.4692.71 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = json.loads(data_text[data_text.find("(") + 1 : data_text.rfind(")")])
     temp_df = pd.DataFrame(data_json)
@@ -842,7 +861,8 @@ def option_finance_minute_sina(symbol: str = "10002530") -> pd.DataFrame:
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/97.0.4692.71 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.json()
     temp_df = pd.DataFrame()
     for item in data_text["result"]["data"]:
@@ -889,7 +909,8 @@ def option_minute_em(symbol: str = "MO2404-P-4450") -> pd.DataFrame:
         "ndays": "1",
         "cb": "quotepushdata1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = json.loads(data_text[data_text.find("(") + 1 : data_text.rfind(")")])
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["trends"]])

--- a/akshare/option/option_lhb_em.py
+++ b/akshare/option/option_lhb_em.py
@@ -6,6 +6,7 @@ Desc: 东方财富网-数据中心-特色数据-期权龙虎榜单
 https://data.eastmoney.com/other/qqlhb.html
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -38,7 +39,8 @@ def option_lhb_em(
         "ut": "b2884a393a59ad64002292a3e90d46a5",
         "_": "1642904215146",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     if indicator == "期权交易情况-认沽交易量":

--- a/akshare/option/option_premium_analysis_em.py
+++ b/akshare/option/option_premium_analysis_em.py
@@ -6,6 +6,7 @@ Desc: 东方财富网-数据中心-特色数据-期权折溢价
 https://data.eastmoney.com/other/premium.html
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -29,7 +30,8 @@ def option_premium_analysis_em() -> pd.DataFrame:
         'fields': 'f1,f2,f3,f12,f13,f14,f161,f250,f330,f331,f332,f333,f334,f335,f337,f301,f152',
         'fs': 'm:10'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = [

--- a/akshare/option/option_risk_analysis_em.py
+++ b/akshare/option/option_risk_analysis_em.py
@@ -6,6 +6,7 @@ Desc: 东方财富网-数据中心-特色数据-期权风险分析
 https://data.eastmoney.com/other/riskanal.html
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -29,7 +30,8 @@ def option_risk_analysis_em() -> pd.DataFrame:
         "fields": "f1,f2,f3,f12,f13,f14,f302,f303,f325,f326,f327,f329,f328,f301,f152,f154",
         "fs": "m:10",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = [

--- a/akshare/option/option_risk_indicator_sse.py
+++ b/akshare/option/option_risk_indicator_sse.py
@@ -5,6 +5,7 @@ Date: 2022/5/18 20:40
 Desc: 上海证券交易所-产品-股票期权-期权风险指标
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -36,7 +37,8 @@ def option_risk_indicator_sse(date: str = "20220516") -> pd.DataFrame:
         "Referer": "http://www.sse.com.cn/",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"])
     temp_df = temp_df[

--- a/akshare/option/option_value_analysis_em.py
+++ b/akshare/option/option_value_analysis_em.py
@@ -6,6 +6,7 @@ Desc: 东方财富网-数据中心-特色数据-期权价值分析
 https://data.eastmoney.com/other/valueAnal.html
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -29,7 +30,8 @@ def option_value_analysis_em() -> pd.DataFrame:
         'fields': 'f1,f2,f3,f12,f13,f14,f298,f299,f249,f300,f330,f331,f332,f333,f334,f335,f336,f301,f152',
         'fs': 'm:10'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = [

--- a/akshare/other/other_car_cpca.py
+++ b/akshare/other/other_car_cpca.py
@@ -8,6 +8,7 @@ http://data.cpcaauto.com/FuelMarket
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def car_market_total_cpca(
@@ -25,7 +26,8 @@ def car_market_total_cpca(
     """
     url = "http://data.cpcaauto.com/api/chartlist"
     params = {"charttype": "1"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     if symbol == "狭义乘用车":
@@ -171,7 +173,8 @@ def __car_market_man_rank_cpca_pifa(symbol: str = "狭义乘用车-累计") -> p
     """
     url = "http://data.cpcaauto.com/api/chartlist"
     params = {"charttype": "2"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     if symbol == "狭义乘用车-累计":
@@ -286,7 +289,8 @@ def __car_market_man_rank_cpca_lingshou(
     """
     url = "http://data.cpcaauto.com/api/chartlist_2"
     params = {"charttype": "2"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     if symbol == "狭义乘用车-累计":
@@ -420,7 +424,8 @@ def __car_market_cate_cpca_pifa(symbol: str = "MPV") -> pd.DataFrame:
     """
     url = "http://data.cpcaauto.com/api/chartlist"
     params = {"charttype": "3"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     if symbol == "MPV":
@@ -538,7 +543,8 @@ def __car_market_cate_cpca_lingshou(
     """
     url = "http://data.cpcaauto.com/api/chartlist"
     params = {"charttype": "3"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     if symbol == "MPV":
@@ -671,7 +677,8 @@ def car_market_country_cpca() -> pd.DataFrame:
     """
     url = "http://data.cpcaauto.com/api/chartlist"
     params = {"charttype": "4"}
-    r = requests.get(url=url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url=url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json[0]["dataList"])
     for item in temp_df.columns[1:]:
@@ -693,7 +700,8 @@ def car_market_segment_cpca(symbol: str = "轿车") -> pd.DataFrame:
     """
     url = "http://data.cpcaauto.com/api/chartlist"
     params = {"charttype": "5"}
-    r = requests.get(url=url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url=url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if symbol == "MPV":
         temp_df = pd.DataFrame(data_json[0]["dataList"])
@@ -730,7 +738,8 @@ def car_market_fuel_cpca(symbol: str = "整体市场") -> pd.DataFrame:
     """
     url = "http://data.cpcaauto.com/api/chartlist"
     params = {"charttype": "6"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if symbol == "整体市场":
         temp_df = pd.DataFrame(data_json[0]["dataList"])

--- a/akshare/other/other_car_gasgoo.py
+++ b/akshare/other/other_car_gasgoo.py
@@ -8,6 +8,7 @@ http://i.gasgoo.com/data/ranking
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -66,7 +67,8 @@ def car_sale_rank_gasgoo(symbol: str = "车企榜", date: str = "202109") -> pd.
         "Chrome/95.0.4638.69 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, json=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     data_json = demjson.decode(data_json["d"])
     temp_df = pd.DataFrame(data_json)

--- a/akshare/pro/client.py
+++ b/akshare/pro/client.py
@@ -9,6 +9,7 @@ from urllib import parse
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 class DataApi:
@@ -42,7 +43,9 @@ class DataApi:
             "X-Token": self.__token,
         }
         url = parse.urljoin(self.__http_url, "/".join([api_name, *kwargs.values()]))
-        res = requests.get(url, headers=headers, timeout=self.__timeout)
+        timeout = self.__timeout
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(url, headers=headers, timeout=timeout)
         if res.status_code != 200:
             raise Exception("连接异常, 请检查您的Token是否过期和输入的参数是否正确")
         data_json = res.json()

--- a/akshare/qhkc_web/qhkc_fund.py
+++ b/akshare/qhkc_web/qhkc_fund.py
@@ -10,6 +10,7 @@ from typing import AnyStr
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures.cons import (
     QHKC_FUND_BS_URL,
@@ -90,7 +91,8 @@ def get_qhkc_fund_bs(
     date = date[:4] + "-" + date[4:6] + "-" + date[6:]
     print(date)
     payload_id = {"date": date}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print("数据获取成功")
     json_data = r.json()
     symbol_name = []
@@ -187,7 +189,8 @@ def get_qhkc_fund_position(
     date = date[:4] + "-" + date[4:6] + "-" + date[6:]
     print(date)
     payload_id = {"date": date}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print(url)
     print("数据获取成功")
     json_data = r.json()
@@ -286,7 +289,8 @@ def get_qhkc_fund_position_change(
     date = date[:4] + "-" + date[4:6] + "-" + date[6:]
     print(date)
     payload_id = {"date": date}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print(url)
     print("数据获取成功")
     json_data = r.json()
@@ -387,7 +391,8 @@ def get_qhkc_fund_money_change(
     date = date[:4] + "-" + date[4:6] + "-" + date[6:]
     print(date)
     payload_id = {"date": date}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print(url)
     print("数据获取成功")
     json_data = r.json()

--- a/akshare/qhkc_web/qhkc_index.py
+++ b/akshare/qhkc_web/qhkc_index.py
@@ -9,6 +9,7 @@ from typing import AnyStr
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures.cons import (
     QHKC_INDEX_URL,
@@ -39,13 +40,15 @@ def get_qhkc_index(name: AnyStr = "奇货商品", url: AnyStr = QHKC_INDEX_URL):
     """
     name_id_dict = {}
     qhkc_index_url = "https://qhkch.com/ajax/official_indexes.php"
-    r = requests.post(qhkc_index_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(qhkc_index_url, headers=headers, timeout=timeout)
     display_name = [item["name"] for item in r.json()["data"]]
     index_id = [item["id"] for item in r.json()["data"]]
     for item in range(len(display_name)):
         name_id_dict[display_name[item]] = index_id[item]
     payload_id = {"id": name_id_dict[name]}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print(name, "数据获取成功")
     json_data = r.json()
     date = json_data["data"]["date"]
@@ -115,13 +118,15 @@ def get_qhkc_index_trend(name: AnyStr = "奇货商品", url: AnyStr = QHKC_INDEX
     """
     name_id_dict = {}
     qhkc_index_url = "https://qhkch.com/ajax/official_indexes.php"
-    r = requests.post(qhkc_index_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(qhkc_index_url, headers=headers, timeout=timeout)
     display_name = [item["name"] for item in r.json()["data"]]
     index_id = [item["id"] for item in r.json()["data"]]
     for item in range(len(display_name)):
         name_id_dict[display_name[item]] = index_id[item]
     payload_id = {"page": 1, "limit": 10, "index": name_id_dict[name], "date": ""}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print(f"{name}期货指数-大资金动向数据获取成功")
     json_data = r.json()
     df_temp = pd.DataFrame()
@@ -168,13 +173,15 @@ def get_qhkc_index_profit_loss(
     """
     name_id_dict = {}
     qhkc_index_url = "https://qhkch.com/ajax/official_indexes.php"
-    r = requests.post(qhkc_index_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(qhkc_index_url, headers=headers, timeout=timeout)
     display_name = [item["name"] for item in r.json()["data"]]
     index_id = [item["id"] for item in r.json()["data"]]
     for item in range(len(display_name)):
         name_id_dict[display_name[item]] = index_id[item]
     payload_id = {"index": name_id_dict[name], "date1": start_date, "date2": end_date}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print(f"{name}期货指数-盈亏分布数据获取成功")
     json_data = r.json()
     indexes = json_data["data"]["indexes"]

--- a/akshare/qhkc_web/qhkc_tool.py
+++ b/akshare/qhkc_web/qhkc_tool.py
@@ -9,6 +9,7 @@ from typing import AnyStr
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.futures.cons import QHKC_TOOL_FOREIGN_URL, QHKC_TOOL_GDP_URL
 
@@ -41,7 +42,8 @@ def qhkc_tool_foreign(url: AnyStr = QHKC_TOOL_FOREIGN_URL):
      美棉花  10/07 23:30      61.69        61.05 -1.037
     """
     payload_id = {"page": 1, "limit": 10}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print("数据获取成功")
     json_data = r.json()
     name = []
@@ -87,7 +89,8 @@ def qhkc_tool_nebula(url: AnyStr = QHKC_TOOL_FOREIGN_URL):
      美棉花  10/07 23:30      61.69        61.05 -1.037
     """
     payload_id = {"page": 1, "limit": 10}
-    r = requests.post(url, data=payload_id)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload_id, headers=headers, timeout=timeout)
     print("数据获取成功")
     json_data = r.json()
     name = []
@@ -163,7 +166,9 @@ def qhkc_tool_gdp(url: AnyStr = QHKC_TOOL_GDP_URL):
      越南     245     7.31%     6.88%  ...   -3.50%   57.50%   3.00    94.67
   捷克共和国     244     2.70%     0.70%  ...    0.90%   32.70%   0.30    10.61
     """
-    data = pd.read_html(url, encoding="utf-8")
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    data = pd.read_html(res.content, encoding="utf-8")
     columns_list = data[0].columns.tolist()
     columns_list[0] = "国家"
     data[0].columns = columns_list

--- a/akshare/rate/repo_rate.py
+++ b/akshare/rate/repo_rate.py
@@ -6,7 +6,8 @@ Desc: 中国外汇交易中心暨全国银行间同业拆借中心-回购定盘�
 """
 import pandas as pd
 import requests
-
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 
 def repo_rate_query(symbol: str = "回购定盘利率") -> pd.DataFrame:
     """
@@ -19,7 +20,10 @@ def repo_rate_query(symbol: str = "回购定盘利率") -> pd.DataFrame:
     """
     if symbol == "回购定盘利率":
         url = "https://www.chinamoney.com.cn/r/cms/www/chinamoney/data/currency/frr-chrt.csv"
-        temp_df = pd.read_csv(url, header=None)
+        headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'}
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(url, headers=headers, timeout=timeout)
+        temp_df = pd.read_csv(BytesIO(res.content), header=None)
         temp_df.dropna(axis=1, inplace=True)
         temp_df.columns = ['date', "FR001", "FR007", "FR014"]
         temp_df['date'] = pd.to_datetime(temp_df['date'], errors="coerce").dt.date
@@ -30,7 +34,10 @@ def repo_rate_query(symbol: str = "回购定盘利率") -> pd.DataFrame:
         return temp_df
     else:
         url = "https://www.chinamoney.com.cn/r/cms/www/chinamoney/data/currency/fdr-chrt.csv"
-        temp_df = pd.read_csv(url, header=None)
+        headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'}
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(url, headers=headers, timeout=timeout)
+        temp_df = pd.read_csv(BytesIO(res.content), header=None)
         temp_df.dropna(axis=1, inplace=True)
         temp_df.columns = ['date', "FDR001", "FDR007", "FDR014"]
         temp_df['date'] = pd.to_datetime(temp_df['date'], errors="coerce").dt.date
@@ -88,7 +95,7 @@ def repo_rate_hist(start_date: str = "20200930", end_date: str = "20201029") -> 
     return temp_df
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     repo_rate_query_df = repo_rate_query(symbol="回购定盘利率")
     print(repo_rate_query_df)
 

--- a/akshare/reits/reits_basic.py
+++ b/akshare/reits/reits_basic.py
@@ -8,6 +8,7 @@ https://www.jisilu.cn/data/cnreits/#CnReits
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def reits_realtime_em() -> pd.DataFrame:
@@ -31,7 +32,8 @@ def reits_realtime_em() -> pd.DataFrame:
         "fields": "f2,f3,f4,f5,f6,f12,f14,f15,f16,f17,f18",
         "_": "1630048369992",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)

--- a/akshare/request_config_manager.py
+++ b/akshare/request_config_manager.py
@@ -175,4 +175,8 @@ def get_headers_and_timeout(headers, timeout):
     return headers, timeout
 
 def change_proxy(proxy: str):
-    dotenv.set_key('.env', 'PROXY', proxy)
+    try:
+        dotenv.set_key('.env', 'PROXY', proxy)
+        print(f"Proxy has been changed to {proxy}.")
+    except Exception as e:
+        print(f"Change failed. Error: {e}")

--- a/akshare/request_config_manager.py
+++ b/akshare/request_config_manager.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+"""
+Date: 2024/4/17 15:00
+Desc: 为akshare的请求添加环境变量用于伪装防止目标网站反爬
+"""
+import os
+from threading import Timer
+import dotenv
+from fake_useragent import UserAgent
+
+global_config_active = False
+timer = None
+global_request_count = 0
+global_max_requests = None
+global_proxy_active = False
+global_use_fake_user_agent = False
+global_set_timeout = None
+global_force = False
+
+def start_config(
+        config_max_time: float = None,
+        config_max_request: int = None,
+        use_proxy: bool = False,
+        use_fake_user_agent: bool = False,
+        set_timeout: float = None,
+        force: bool = False
+        ):
+    if not use_proxy and not use_fake_user_agent and set_timeout is None:
+        raise ValueError("At least one parameter must be set.")
+    if config_max_time is not None:
+        if config_max_time <= 0:
+            raise ValueError("max_time must be greater than 0.")
+    if config_max_request is not None:
+        if config_max_request <= 0:
+            raise ValueError("max_request must be greater than 0.")
+    if set_timeout is not None:
+        if set_timeout < 0:
+            raise ValueError("timeout must be greater than or equal to 0.")
+    global global_config_active
+    global global_max_requests
+    global global_use_fake_user_agent
+    global global_set_timeout
+    global global_force
+    if global_config_active:
+        stop_config()
+    if config_max_time:
+        timer_start(max_time = config_max_time)
+    if config_max_request:
+        global_max_requests = config_max_request
+        add_request_monitoring()
+    if use_proxy:
+        proxy_on()
+    if use_fake_user_agent:
+        global_use_fake_user_agent = use_fake_user_agent
+    if set_timeout:
+        global_set_timeout = set_timeout
+    if force:
+        global_force = force
+    global_config_active = True
+    print(f"""
+            config is now active.
+            max_time: {config_max_time}
+            max_request: {config_max_request}
+            use_proxy: {use_proxy}
+            use_user_agent: {use_fake_user_agent}
+            set_timeout: {set_timeout}
+            force: {force}
+            """)
+
+def stop_config():
+    remove_request_monitoring()
+    timer_stop()
+    proxy_off()
+    global global_config_active
+    global global_use_fake_user_agent
+    global global_set_timeout
+    global global_force
+    global_config_active = False
+    global_use_fake_user_agent = False
+    global_set_timeout = None
+    global_force = False
+    print("Request config has been deactivated.")
+
+def add_request_monitoring():
+    import akshare as ak
+    global global_request_count
+    global_request_count = 0
+    for func_name in dir(ak):
+        func = getattr(ak, func_name)
+        if callable(func):
+            setattr(ak, func_name, monitored_call(func))
+
+def remove_request_monitoring():
+    import akshare as ak
+    global global_request_count
+    global global_max_requests
+    global_request_count = 0
+    if global_max_requests:
+        global_max_requests = None
+        for func_name in dir(ak):
+            func = getattr(ak, func_name)
+            if callable(func) and isinstance(func, monitored_call.__class__):
+                original_func = func.__wrapped__
+                setattr(ak, func_name, original_func)
+
+def monitored_call(func):
+    def wrapper(*args, **kwargs):
+        global global_request_count
+        global global_max_requests
+        if func.__name__ in ['start_config', 'stop_config', 'change_proxy']:
+            return func(*args, **kwargs)              
+        result = func(*args, **kwargs)
+        global_request_count += 1
+        if global_max_requests:
+            if global_request_count >= global_max_requests:
+                print("Request limit reached. config will now stop.")
+                stop_config()
+        return result    
+    wrapper.__wrapped__ = func
+    return wrapper
+
+def proxy_on():
+    dotenv.load_dotenv()
+    global global_proxy_active
+    if global_proxy_active:
+        proxy_off()
+        global_proxy_active = False
+    os.environ['HTTP_PROXY'] = os.getenv('PROXY', 'default_http_proxy')
+    os.environ['HTTPS_PROXY'] = os.getenv('PROXY', 'default_http_proxy')
+    global_proxy_active = True
+
+def proxy_off():
+    global global_proxy_active
+    if global_proxy_active:
+        if 'HTTP_PROXY' in os.environ:
+            del os.environ['HTTP_PROXY']
+        if 'HTTPS_PROXY' in os.environ:
+            del os.environ['HTTPS_PROXY']
+        global_proxy_active = False
+
+def timer_start(max_time):
+    global timer
+    timer = Timer(max_time, stop_config_time)
+    timer.start()
+
+def stop_config_time():
+    print("Time limit reached. Request config will now stop.")
+    stop_config()
+
+def timer_stop():
+    global timer
+    if timer:
+        timer.cancel()
+        timer = None
+
+def get_headers_and_timeout(headers, timeout):
+    global global_use_fake_user_agent
+    global global_set_timeout
+    global global_force
+    if global_use_fake_user_agent:
+        if 'User-Agent' in headers:
+            if global_force:
+                ua = UserAgent().random
+                headers.update({'User-Agent': ua})
+        else:
+            ua = UserAgent().random
+            headers.update({'User-Agent': ua})
+    if global_set_timeout is not None:
+        if timeout is not None:
+            if global_force:
+                timeout = global_set_timeout
+        else:
+            timeout = global_set_timeout
+    return headers, timeout
+
+def change_proxy(proxy: str):
+    dotenv.set_key('.env', 'PROXY', proxy)

--- a/akshare/sport/sport_olympic.py
+++ b/akshare/sport/sport_olympic.py
@@ -6,6 +6,9 @@ Desc: 运动-奥运会
 https://www.kaggle.com/marcogdepinto/let-s-discover-more-about-the-olympic-games
 """
 import pandas as pd
+import requests
+from akshare.request_config_manager import get_headers_and_timeout
+from io import BytesIO
 
 
 def sport_olympic_hist() -> pd.DataFrame:
@@ -16,7 +19,9 @@ def sport_olympic_hist() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://jfds-1252952517.cos.ap-chengdu.myqcloud.com/akshare/data/data_olympic/athlete_events.zip"
-    temp_df = pd.read_csv(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
+    temp_df = pd.read_csv(BytesIO(res.content), compression='zip')
     columns_list = [item.lower() for item in temp_df.columns.tolist()]
     temp_df.columns = columns_list
     return temp_df

--- a/akshare/sport/sport_olympic_winter.py
+++ b/akshare/sport/sport_olympic_winter.py
@@ -6,6 +6,7 @@ Desc: 腾讯运动-冬奥会-历届奖牌榜
 https://m.sports.qq.com/g/sv3/winter-oly22/winter-olympic-rank.htm?type=0
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -16,7 +17,8 @@ def sport_olympic_winter_hist() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://app.sports.qq.com/m/oly/historyMedal"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["list"])
     temp_df = temp_df.explode("list")

--- a/akshare/spot/spot_sge.py
+++ b/akshare/spot/spot_sge.py
@@ -9,6 +9,7 @@ https://www.sge.com.cn/sjzx/mrhq
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def spot_symbol_table_sge() -> pd.DataFrame:
@@ -76,7 +77,8 @@ def spot_hist_sge(symbol: str = "Au99.99") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["time"])
     temp_df.columns = [
@@ -107,7 +109,8 @@ def spot_golden_benchmark_sge() -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36",
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["wp"])
     temp_df.columns = [
@@ -141,7 +144,8 @@ def spot_silver_benchmark_sge() -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36",
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["wp"])
     temp_df.columns = [

--- a/akshare/stock/stock_allotment_cninfo.py
+++ b/akshare/stock/stock_allotment_cninfo.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/#/dataBrowse
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -69,7 +70,8 @@ def stock_allotment_cninfo(
         "Referer": "http://webapi.cninfo.com.cn/",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     columns = [
         "记录标识",

--- a/akshare/stock/stock_ask_bid_em.py
+++ b/akshare/stock/stock_ask_bid_em.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 @lru_cache()
@@ -34,7 +35,8 @@ def __code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -55,7 +57,8 @@ def __code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -75,7 +78,8 @@ def __code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -109,7 +113,8 @@ def stock_bid_ask_em(symbol: str = "000001") -> pd.DataFrame:
         "f276,f265,f266,f289,f290,f286,f285,f292,f293,f294,f295",
         "secid": f"{code_id_map_em_dict[symbol]}.{symbol}",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     tick_dict = {
         "sell_5": data_json["data"]["f31"],

--- a/akshare/stock/stock_board_concept_em.py
+++ b/akshare/stock/stock_board_concept_em.py
@@ -7,6 +7,7 @@ https://quote.eastmoney.com/center/boardlist.html#concept_board
 """
 
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -31,7 +32,8 @@ def stock_board_concept_name_em() -> pd.DataFrame:
         "fields": "f2,f3,f4,f8,f12,f14,f15,f16,f17,f18,f20,f21,f24,f25,f22,f33,f11,f62,f128,f124,f107,f104,f105,f136",
         "_": "1626075887768",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)
@@ -141,7 +143,8 @@ def stock_board_concept_hist_em(
         "lmt": "1000000",
         "_": "1626079488673",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])
     temp_df.columns = [
@@ -213,7 +216,8 @@ def stock_board_concept_hist_min_em(
             "secid": f"90.{stock_board_code}",
             "_": "1687852931312",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["trends"]]
@@ -249,7 +253,8 @@ def stock_board_concept_hist_min_em(
             "lmt": "1000000",
             "_": "1647760607065",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]
@@ -323,7 +328,8 @@ def stock_board_concept_cons_em(symbol: str = "车联网") -> pd.DataFrame:
         "f24,f25,f22,f11,f62,f128,f136,f115,f152,f45",
         "_": "1626081702127",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock/stock_board_industry_em.py
+++ b/akshare/stock/stock_board_industry_em.py
@@ -9,6 +9,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_board_industry_name_em() -> pd.DataFrame:
@@ -32,7 +33,8 @@ def stock_board_industry_name_em() -> pd.DataFrame:
         "fields": "f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f12,f13,f14,f15,f16,f17,f18,f20,f21,f23,f24,f25,f26,f22,f33,f11,f62,f128,f136,f115,f152,f124,f107,f104,f105,f140,f141,f207,f208,f209,f222",
         "_": "1626075887768",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)
@@ -145,7 +147,8 @@ def stock_board_industry_spot_em(symbol: str = "小金属") -> pd.DataFrame:
         secid=f"90.{em_code}",
         ut="fa5fd1943c7b386f172d6893dbfba10b",
     )
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_dict = r.json()
     result = pd.DataFrame.from_dict(data_dict["data"], orient="index")
     result.rename(field_map, inplace=True)
@@ -207,7 +210,8 @@ def stock_board_industry_hist_em(
         "lmt": "1000000",
         "_": "1626079488673",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(
         [item.split(",") for item in data_json["data"]["klines"]]
@@ -281,7 +285,8 @@ def stock_board_industry_hist_min_em(
             "secid": f"90.{stock_board_code}",
             "_": "1687852931312",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["trends"]]
@@ -320,7 +325,8 @@ def stock_board_industry_hist_min_em(
             "lmt": "1000000",
             "_": "1626079488673",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]
@@ -393,7 +399,8 @@ def stock_board_industry_cons_em(symbol: str = "小金属") -> pd.DataFrame:
         "fields": "f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f12,f13,f14,f15,f16,f17,f18,f20,f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152,f45",
         "_": "1626081702127",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock/stock_cg_equity_mortgage.py
+++ b/akshare/stock/stock_cg_equity_mortgage.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/#/thematicStatistics
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -58,7 +59,8 @@ def stock_cg_equity_mortgage_cninfo(date: str = "20210930") -> pd.DataFrame:
     params = {
         "tdate": "-".join([date[:4], date[4:6], date[6:]]),
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_cg_guarantee.py
+++ b/akshare/stock/stock_cg_guarantee.py
@@ -9,6 +9,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 js_str = """
@@ -89,7 +90,8 @@ def stock_cg_guarantee_cninfo(
         "edate": "-".join([end_date[:4], end_date[4:6], end_date[6:]]),
         "market": symbol_map[symbol],
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_cg_lawsuit.py
+++ b/akshare/stock/stock_cg_lawsuit.py
@@ -9,6 +9,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 js_str = """
@@ -89,7 +90,8 @@ def stock_cg_lawsuit_cninfo(
         "edate": "-".join([end_date[:4], end_date[4:6], end_date[6:]]),
         "market": symbol_map[symbol],
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_dividend_cninfo.py
+++ b/akshare/stock/stock_dividend_cninfo.py
@@ -7,6 +7,7 @@ https://webapi.cninfo.com.cn/#/company?companyid=600009
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -56,7 +57,8 @@ def stock_dividend_cninfo(symbol: str = "600009") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_dzjy_em.py
+++ b/akshare/stock/stock_dzjy_em.py
@@ -7,6 +7,7 @@ http://data.eastmoney.com/dzjy/dzjy_sctj.aspx
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_dzjy_sctj() -> pd.DataFrame:
@@ -27,13 +28,15 @@ def stock_dzjy_sctj() -> pd.DataFrame:
         'source': 'WEB',
         'client': 'WEB',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = int(data_json['result']["pages"])
     big_df = pd.DataFrame()
     for page in range(1, total_page+1):
         params.update({'pageNumber': page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -92,7 +95,8 @@ def stock_dzjy_mrmx(symbol: str = '基金', start_date: str = '20220104', end_da
         'client': 'WEB',
         'filter': f"""(SECURITY_TYPE_WEB={symbol_map[symbol]})(TRADE_DATE>='{'-'.join([start_date[:4], start_date[4:6], start_date[6:]])}')(TRADE_DATE<='{'-'.join([end_date[:4], end_date[4:6], end_date[6:]])}')"""
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json['result']["data"]:
         return pd.DataFrame()
@@ -209,7 +213,8 @@ def stock_dzjy_mrtj(start_date: str = '20220105', end_date: str = '20220105') ->
         'client': 'WEB',
         'filter': f"(TRADE_DATE>='{'-'.join([start_date[:4], start_date[4:6], start_date[6:]])}')(TRADE_DATE<='{'-'.join([end_date[:4], end_date[4:6], end_date[6:]])}')"
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result']["data"])
     temp_df.reset_index(inplace=True)
@@ -286,13 +291,15 @@ def stock_dzjy_hygtj(symbol: str = '近三月') -> pd.DataFrame:
         'client': 'WEB',
         'filter': f'(DATE_TYPE_CODE={period_map[symbol]})',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json['result']["pages"]
     big_df = pd.DataFrame()
     for page in range(1, int(total_page)+1):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -380,13 +387,15 @@ def stock_dzjy_hyyybtj(symbol: str = '近3日') -> pd.DataFrame:
         'client': 'WEB',
         'filter': f'(N_DATE=-{period_map[symbol]})',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json['result']["pages"]
     big_df = pd.DataFrame()
     for page in range(1, int(total_page)+1):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -452,13 +461,15 @@ def stock_dzjy_yybph(symbol: str = '近三月') -> pd.DataFrame:
         'client': 'WEB',
         'filter': f'(N_DATE=-{period_map[symbol]})',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json['result']["pages"]
     big_df = pd.DataFrame()
     for page in range(1, int(total_page)+1):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock/stock_fund_em.py
+++ b/akshare/stock/stock_fund_em.py
@@ -12,6 +12,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_individual_fund_flow(
@@ -42,7 +43,8 @@ def stock_individual_fund_flow(
         "ut": "b2884a393a59ad64002292a3e90d46a5",
         "_": int(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     json_data = r.json()
     content_list = json_data["data"]["klines"]
     temp_df = pd.DataFrame([item.split(",") for item in content_list])
@@ -155,7 +157,8 @@ def stock_individual_fund_flow_rank(indicator: str = "5日") -> pd.DataFrame:
         "fs": "m:0+t:6+f:!2,m:0+t:13+f:!2,m:0+t:80+f:!2,m:1+t:2+f:!2,m:1+t:23+f:!2,m:0+t:7+f:!2,m:1+t:3+f:!2",
         "fields": indicator_map[indicator][1],
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)
@@ -350,7 +353,8 @@ def stock_market_fund_flow() -> pd.DataFrame:
         "cb": "jQuery183003743205523325188_1589197499471",
         "_": int(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     json_data = json.loads(text_data[text_data.find("{"): -2])
     content_list = json_data["data"]["klines"]
@@ -481,7 +485,8 @@ def stock_sector_fund_flow_rank(
         "cb": "jQuery18308357908311220152_1589256588824",
         "_": int(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     json_data = json.loads(text_data[text_data.find("{"): -2])
     temp_df = pd.DataFrame(json_data["data"]["diff"])
@@ -648,7 +653,8 @@ def _get_stock_sector_fund_flow_summary_code() -> dict:
         "rt": "52975239",
         "_": int(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     name_code_map = dict(zip(temp_df["f14"], temp_df["f12"]))
@@ -682,7 +688,8 @@ def stock_sector_fund_flow_summary(
             "fs": f"b:{code_name_map[symbol]}",
             "fields": "f12,f14,f2,f3,f62,f184,f66,f69,f72,f75,f78,f81,f84,f87,f204,f205,f124,f1,f13",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["diff"])
         temp_df.reset_index(inplace=True)
@@ -771,7 +778,8 @@ def stock_sector_fund_flow_summary(
             "fs": f"b:{code_name_map[symbol]}",
             "fields": "f12,f14,f2,f109,f164,f165,f166,f167,f168,f169,f170,f171,f172,f173,f257,f258,f124,f1,f13",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["diff"])
         temp_df.reset_index(inplace=True)
@@ -860,7 +868,8 @@ def stock_sector_fund_flow_summary(
             "fs": f"b:{code_name_map[symbol]}",
             "fields": "f12,f14,f2,f160,f174,f175,f176,f177,f178,f179,f180,f181,f182,f183,f260,f261,f124,f1,f13",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["diff"])
         temp_df.reset_index(inplace=True)
@@ -958,7 +967,8 @@ def stock_sector_fund_flow_hist(symbol: str = "电源设备") -> pd.DataFrame:
         "secid": f"90.{code_name_map[symbol]}",
         "_": "1678954135116",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])
     temp_df.columns = [
@@ -1051,7 +1061,8 @@ def _get_stock_concept_fund_flow_summary_code() -> dict:
         "ut": "b2884a393a59ad64002292a3e90d46a5",
         "_": int(time.time() * 1000),
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     name_code_map = dict(zip(temp_df["f14"], temp_df["f12"]))
@@ -1077,7 +1088,8 @@ def stock_concept_fund_flow_hist(symbol: str = "锂电池") -> pd.DataFrame:
         "secid": f"90.{code_name_map[symbol]}",
         "_": "1678954135116",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])
     temp_df.columns = [
@@ -1178,7 +1190,9 @@ def stock_main_fund_flow(symbol: str = "全部股票") -> pd.DataFrame:
         "ut": "b2884a393a59ad64002292a3e90d46a5",
         "fs": symbol_map[symbol],
     }
-    r = requests.get(url, params=params, timeout=15)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, timeout=timeout, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock/stock_fund_hold.py
+++ b/akshare/stock/stock_fund_hold.py
@@ -7,6 +7,7 @@ http://data.eastmoney.com/zlsj/2020-06-30-1-2.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -45,7 +46,8 @@ def stock_report_fund_hold(
         "p": "1",
         "pageNo": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["pages"]
     big_df = pd.DataFrame()
@@ -61,7 +63,8 @@ def stock_report_fund_hold(
             "p": page,
             "pageNo": page,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -135,7 +138,8 @@ def stock_report_fund_hold_detail(
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock/stock_gsrl_em.py
+++ b/akshare/stock/stock_gsrl_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/gsrl/gsdt.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_gsrl_gsdt_em(date: str = "20230808") -> pd.DataFrame:
@@ -30,7 +31,8 @@ def stock_gsrl_gsdt_em(date: str = "20230808") -> pd.DataFrame:
         "reportName": "RPT_ORGOP_ALL",
         "filter": f"""(TRADE_DATE='{"-".join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock/stock_hk_fhpx_ths.py
+++ b/akshare/stock/stock_hk_fhpx_ths.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_hk_fhpx_detail_ths(symbol: str = "0700") -> pd.DataFrame:
@@ -26,7 +27,8 @@ def stock_hk_fhpx_detail_ths(symbol: str = "0700") -> pd.DataFrame:
         "AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df.columns = [

--- a/akshare/stock/stock_hk_hot_rank_em.py
+++ b/akshare/stock/stock_hk_hot_rank_em.py
@@ -7,6 +7,7 @@ https://guba.eastmoney.com/rank/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_hk_hot_rank_em() -> pd.DataFrame:
@@ -24,7 +25,8 @@ def stock_hk_hot_rank_em() -> pd.DataFrame:
         "pageNo": 1,
         "pageSize": 100,
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_rank_df = pd.DataFrame(data_json["data"])
     temp_rank_df["mark"] = ["116." + item[3:] for item in temp_rank_df["sc"]]
@@ -36,7 +38,8 @@ def stock_hk_hot_rank_em() -> pd.DataFrame:
         "secids": ",".join(temp_rank_df["mark"]) + ",?v=08926209912590994",
     }
     url = "https://push2.eastmoney.com/api/qt/ulist.np/get"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = ["最新价", "涨跌幅", "代码", "股票名称"]
@@ -72,7 +75,8 @@ def stock_hk_hot_rank_detail_em(symbol: str = "00700") -> pd.DataFrame:
         "marketType": "000003",
         "srcSecurityCode": f"HK|{symbol}",
     }
-    r = requests.post(url_rank, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url_rank, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["证券代码"] = symbol
@@ -97,7 +101,8 @@ def stock_hk_hot_rank_detail_realtime_em(symbol: str = "00700") -> pd.DataFrame:
         "marketType": "000003",
         "srcSecurityCode": f"HK|{symbol}",
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["时间", "排名"]
@@ -120,7 +125,8 @@ def stock_hk_hot_rank_latest_em(symbol: str = "00700") -> pd.DataFrame:
         "marketType": "000003",
         "srcSecurityCode": f"HK|{symbol}",
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame.from_dict(data_json["data"], orient="index")
     temp_df.reset_index(inplace=True)

--- a/akshare/stock/stock_hk_sina.py
+++ b/akshare/stock/stock_hk_sina.py
@@ -7,6 +7,7 @@ http://stock.finance.sina.com.cn/hkstock/quotes/00700.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.stock.cons import (
@@ -27,7 +28,8 @@ def stock_hk_spot() -> pd.DataFrame:
     :return: 实时行情数据
     :rtype: pandas.DataFrame
     """
-    res = requests.get(hk_sina_stock_list_url, params=hk_sina_stock_dict_payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(hk_sina_stock_list_url, params=hk_sina_stock_dict_payload, headers=headers, timeout=timeout)
     data_json = [
         demjson.decode(tt)
         for tt in [
@@ -69,7 +71,8 @@ def stock_hk_daily(symbol: str = "00981", adjust: str = "") -> pd.DataFrame:
     :return: 指定 adjust 的数据
     :rtype: pandas.DataFrame
     """
-    r = requests.get(hk_sina_stock_hist_url.format(symbol))
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(hk_sina_stock_hist_url.format(symbol), headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)
     dict_list = js_code.call(
@@ -86,7 +89,8 @@ def stock_hk_daily(symbol: str = "00981", adjust: str = "") -> pd.DataFrame:
         return data_df
 
     if adjust == "hfq":
-        r = requests.get(hk_sina_stock_hist_hfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(hk_sina_stock_hist_hfq_url.format(symbol), headers=headers, timeout=timeout)
         try:
             hfq_factor_df = pd.DataFrame(
                 eval(r.text.split("=")[1].split("\n")[0])["data"]
@@ -150,7 +154,8 @@ def stock_hk_daily(symbol: str = "00981", adjust: str = "") -> pd.DataFrame:
         return temp_df
 
     if adjust == "qfq":
-        r = requests.get(hk_sina_stock_hist_qfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(hk_sina_stock_hist_qfq_url.format(symbol), headers=headers, timeout=timeout)
         try:
             qfq_factor_df = pd.DataFrame(
                 eval(r.text.split("=")[1].split("\n")[0])["data"]
@@ -215,7 +220,8 @@ def stock_hk_daily(symbol: str = "00981", adjust: str = "") -> pd.DataFrame:
         return temp_df
 
     if adjust == "hfq-factor":
-        r = requests.get(hk_sina_stock_hist_hfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(hk_sina_stock_hist_hfq_url.format(symbol), headers=headers, timeout=timeout)
         hfq_factor_df = pd.DataFrame(eval(r.text.split("=")[1].split("\n")[0])["data"])
         hfq_factor_df.columns = ["date", "hfq_factor", "cash"]
         hfq_factor_df.index = pd.to_datetime(hfq_factor_df.date)
@@ -225,7 +231,8 @@ def stock_hk_daily(symbol: str = "00981", adjust: str = "") -> pd.DataFrame:
         return hfq_factor_df
 
     if adjust == "qfq-factor":
-        r = requests.get(hk_sina_stock_hist_qfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(hk_sina_stock_hist_qfq_url.format(symbol), headers=headers, timeout=timeout)
         qfq_factor_df = pd.DataFrame(eval(r.text.split("=")[1].split("\n")[0])["data"])
         qfq_factor_df.columns = ["date", "qfq_factor"]
         qfq_factor_df.index = pd.to_datetime(qfq_factor_df.date)

--- a/akshare/stock/stock_hold_control_cninfo.py
+++ b/akshare/stock/stock_hold_control_cninfo.py
@@ -12,6 +12,7 @@ import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -70,7 +71,8 @@ def stock_hold_control_cninfo(symbol: str = "全部") -> pd.DataFrame:
     params = {
         "ctype": symbol_map[symbol],
     }
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [
@@ -140,7 +142,8 @@ def stock_hold_management_detail_cninfo(symbol: str = "增持") -> pd.DataFrame:
         "edate": current_date,
         "varytype": symbol_map[symbol],
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_hold_control_em.py
+++ b/akshare/stock/stock_hold_control_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/executive/list.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -34,7 +35,8 @@ def stock_hold_management_detail_em() -> pd.DataFrame:
         "pageNum": "1",
         "_": "1691501763413",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -47,7 +49,8 @@ def stock_hold_management_detail_em() -> pd.DataFrame:
                 "pageNum": page,
             }
         )
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -135,7 +138,8 @@ def stock_hold_management_person_em(
         "client": "WEB",
         "_": "1691503078611",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(

--- a/akshare/stock/stock_hold_num_cninfo.py
+++ b/akshare/stock/stock_hold_num_cninfo.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/#/thematicStatistics
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -58,7 +59,8 @@ def stock_hold_num_cninfo(date: str = "20210630") -> pd.DataFrame:
     params = {
         "rdate": date,
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_hot_rank_em.py
+++ b/akshare/stock/stock_hot_rank_em.py
@@ -7,6 +7,7 @@ https://guba.eastmoney.com/rank/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_hot_rank_em() -> pd.DataFrame:
@@ -24,7 +25,8 @@ def stock_hot_rank_em() -> pd.DataFrame:
         "pageNo": 1,
         "pageSize": 100,
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_rank_df = pd.DataFrame(data_json["data"])
 
@@ -41,7 +43,8 @@ def stock_hot_rank_em() -> pd.DataFrame:
         "secids": ",".join(temp_rank_df["mark"]) + ",?v=08926209912590994",
     }
     url = "https://push2.eastmoney.com/api/qt/ulist.np/get"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = ["最新价", "涨跌幅", "代码", "股票名称"]
@@ -80,7 +83,8 @@ def stock_hot_rank_detail_em(symbol: str = "SZ000665") -> pd.DataFrame:
         "marketType": "",
         "srcSecurityCode": symbol,
     }
-    r = requests.post(url_rank, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url_rank, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["证券代码"] = symbol
@@ -88,7 +92,8 @@ def stock_hot_rank_detail_em(symbol: str = "SZ000665") -> pd.DataFrame:
     temp_df = temp_df[["时间", "排名", "证券代码"]]
 
     url_follow = "https://emappdata.eastmoney.com/stockrank/getHisProfileList"
-    r = requests.post(url_follow, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url_follow, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df["新晋粉丝"] = (
         pd.DataFrame(data_json["data"])["newUidRate"].str.strip("%").astype(float) / 100
@@ -115,7 +120,8 @@ def stock_hot_rank_detail_realtime_em(symbol: str = "SZ000665") -> pd.DataFrame:
         "marketType": "",
         "srcSecurityCode": symbol,
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df.columns = ["时间", "排名"]
@@ -137,7 +143,8 @@ def stock_hot_keyword_em(symbol: str = "SZ000665") -> pd.DataFrame:
         "globalId": "786e4c21-70dc-435a-93bb-38",
         "srcSecurityCode": symbol,
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     del temp_df["flag"]
@@ -161,7 +168,8 @@ def stock_hot_rank_latest_em(symbol: str = "SZ000665") -> pd.DataFrame:
         "marketType": "",
         "srcSecurityCode": symbol,
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame.from_dict(data_json["data"], orient="index")
     temp_df.reset_index(inplace=True)
@@ -184,7 +192,8 @@ def stock_hot_rank_relate_em(symbol: str = "SZ000665") -> pd.DataFrame:
         "globalId": "786e4c21-70dc-435a-93bb-38",
         "srcSecurityCode": symbol,
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame.from_dict(data_json["data"])
     temp_df.columns = ["时间", "-", "股票代码", "-", "相关股票代码", "涨跌幅", "-"]

--- a/akshare/stock/stock_hot_search_baidu.py
+++ b/akshare/stock/stock_hot_search_baidu.py
@@ -7,6 +7,7 @@ https://gushitong.baidu.com/expressnews
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from datetime import datetime
 
 
@@ -43,7 +44,8 @@ def stock_hot_search_baidu(symbol: str = "A股", date: str = "20230428", time: s
         "type": "day" if time == "今日" else "hour",
         "finClientType": "pc",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(
         data_json["Result"]["body"], columns=data_json["Result"]["header"]

--- a/akshare/stock/stock_hot_up_em.py
+++ b/akshare/stock/stock_hot_up_em.py
@@ -7,6 +7,7 @@ https://guba.eastmoney.com/rank/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_hot_up_em() -> pd.DataFrame:
@@ -24,7 +25,8 @@ def stock_hot_up_em() -> pd.DataFrame:
         "pageNo": 1,
         "pageSize": 100,
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_rank_df = pd.DataFrame(data_json["data"])
 
@@ -41,7 +43,8 @@ def stock_hot_up_em() -> pd.DataFrame:
         "secids": ",".join(temp_rank_df["mark"]) + ",?v=08926209912590994",
     }
     url = "https://push2.eastmoney.com/api/qt/ulist.np/get"
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = ["最新价", "涨跌幅", "代码", "股票名称"]

--- a/akshare/stock/stock_industry.py
+++ b/akshare/stock/stock_industry.py
@@ -10,6 +10,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 from tqdm import tqdm
@@ -26,23 +27,28 @@ def stock_sector_spot(indicator: str = "新浪行业") -> pd.DataFrame:
     """
     if indicator == "新浪行业":
         url = "http://vip.stock.finance.sina.com.cn/q/view/newSinaHy.php"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
     if indicator == "启明星行业":
         url = "http://biz.finance.sina.com.cn/hq/qmxIndustryHq.php"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         r.encoding = "gb2312"
     if indicator == "概念":
         url = "http://money.finance.sina.com.cn/q/view/newFLJK.php"
         params = {"param": "class"}
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
     if indicator == "地域":
         url = "http://money.finance.sina.com.cn/q/view/newFLJK.php"
         params = {"param": "area"}
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
     if indicator == "行业":
         url = "http://money.finance.sina.com.cn/q/view/newFLJK.php"
         params = {"param": "industry"}
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     json_data = json.loads(text_data[text_data.find("{") :])
     temp_df = pd.DataFrame([value.split(",") for key, value in json_data.items()])
@@ -84,7 +90,8 @@ def stock_sector_detail(sector: str = "gn_gfgn") -> pd.DataFrame:
     """
     url = "http://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getHQNodeStockCount"
     params = {"node": sector}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     total_num = int(r.json())
     total_page_num = math.ceil(int(total_num) / 80)
     big_df = pd.DataFrame()
@@ -99,7 +106,8 @@ def stock_sector_detail(sector: str = "gn_gfgn") -> pd.DataFrame:
             "symbol": "",
             "_s_r_a": "page",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text)
         temp_df = pd.DataFrame(data_json)

--- a/akshare/stock/stock_industry_cninfo.py
+++ b/akshare/stock/stock_industry_cninfo.py
@@ -9,6 +9,7 @@ http://webapi.cninfo.com.cn/api/stock/p_stock2110
 import numpy as np
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -69,7 +70,8 @@ def stock_industry_category_cninfo(symbol: str = "巨潮行业分类标准") -> 
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     cols_map = {
@@ -141,7 +143,8 @@ def stock_industry_change_cninfo(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     cols_map = {

--- a/akshare/stock/stock_industry_pe_cninfo.py
+++ b/akshare/stock/stock_industry_pe_cninfo.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/#/thematicStatistics?name=%E6%8A%95%E8%B5%84%E8%AF%8
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -64,7 +65,8 @@ def stock_industry_pe_ratio_cninfo(symbol: str = "证监会行业分类", date: 
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_industry_sw.py
+++ b/akshare/stock/stock_industry_sw.py
@@ -10,6 +10,7 @@ import io
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_industry_clf_hist_sw() -> pd.DataFrame:
@@ -26,7 +27,8 @@ def stock_industry_clf_hist_sw() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/102.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_excel(
         io.BytesIO(r.content), dtype={"股票代码": "str", "行业代码": "str"}
     )

--- a/akshare/stock/stock_info.py
+++ b/akshare/stock/stock_info.py
@@ -12,6 +12,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from akshare.utils.tqdm import get_tqdm
 
 
@@ -38,7 +39,9 @@ def stock_info_sz_name_code(symbol: str = "A股列表") -> pd.DataFrame:
         "TABKEY": indicator_map[symbol],
         "random": "0.6935816432433362",
     }
-    r = requests.get(url, params=params, timeout=15)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, timeout=timeout, headers=headers)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         temp_df = pd.read_excel(BytesIO(r.content))
@@ -151,7 +154,8 @@ def stock_info_sh_name_code(symbol: str = "主板A股") -> pd.DataFrame:
         "pageHelp.endPage": "1",
         "_": "1653291270045",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"])
     col_stock_code = "B_STOCK_CODE" if symbol == "主板B股" else "A_STOCK_CODE"
@@ -196,7 +200,8 @@ def stock_info_bj_name_code() -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"
     }
-    r = requests.post(url, data=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = json.loads(data_text[data_text.find("["): -1])
     total_page = data_json[0]["totalPages"]
@@ -204,7 +209,8 @@ def stock_info_bj_name_code() -> pd.DataFrame:
     tqdm = get_tqdm()
     for page in tqdm(range(total_page), leave=False):
         payload.update({"page": page})
-        r = requests.post(url, data=payload, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, data=payload, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = json.loads(data_text[data_text.find("["): -1])
         temp_df = data_json[0]["content"]
@@ -319,7 +325,8 @@ def stock_info_sh_delist(symbol: str = "全部") -> pd.DataFrame:
         "pageHelp.endPage": "1",
         "_": "1643035608183",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"])
     temp_df.rename(
@@ -361,7 +368,8 @@ def stock_info_sz_delist(symbol: str = "暂停上市公司") -> pd.DataFrame:
         "TABKEY": indicator_map[symbol],
         "random": "0.6935816432433362",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         temp_df = pd.read_excel(BytesIO(r.content))
@@ -390,7 +398,8 @@ def stock_info_sz_change_name(symbol: str = "全称变更") -> pd.DataFrame:
         "TABKEY": indicator_map[symbol],
         "random": "0.6935816432433362",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         temp_df = pd.read_excel(BytesIO(r.content))
@@ -410,7 +419,8 @@ def stock_info_change_name(symbol: str = "000503") -> pd.DataFrame:
     :rtype: list
     """
     url = f"https://vip.stock.finance.sina.com.cn/corp/go.php/vCI_CorpInfo/stockid/{symbol}.phtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[3].iloc[:, :2]
     temp_df.dropna(inplace=True)
     temp_df.columns = ["item", "value"]

--- a/akshare/stock/stock_info_em.py
+++ b/akshare/stock/stock_info_em.py
@@ -7,6 +7,7 @@ https://quote.eastmoney.com/concept/sh603777.html?from=classic
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock_feature.stock_hist_em import code_id_map_em
 
@@ -32,7 +33,8 @@ def stock_individual_info_em(symbol: str = "603777", timeout: float = None) -> p
         "secid": f"{code_id_dict[symbol]}.{symbol}",
         "_": "1640157544804",
     }
-    r = requests.get(url, params=params, timeout=timeout)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, timeout=timeout, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
     temp_df.reset_index(inplace=True)

--- a/akshare/stock/stock_intraday_em.py
+++ b/akshare/stock/stock_intraday_em.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 @lru_cache()
@@ -34,7 +35,8 @@ def __code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -55,7 +57,8 @@ def __code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -75,7 +78,8 @@ def __code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -87,7 +91,8 @@ def __code_id_map_em() -> dict:
 
 def __event_stream(url, params):
     # 使用 stream=True 参数来启用流式请求
-    response = requests.get(url, params=params, stream=True)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    response = requests.get(url, params=params, stream=True, headers=headers, timeout=timeout)
     event_data = ""
 
     for line in response.iter_lines():

--- a/akshare/stock/stock_intraday_sina.py
+++ b/akshare/stock/stock_intraday_sina.py
@@ -10,6 +10,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -44,7 +45,8 @@ def stock_intraday_sina(
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/107.0.0.0 Safari/537.36",
     }
-    r = requests.get(url=url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url=url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = math.ceil(int(data_json) / 60)
     url = "https://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/CN_Bill.GetBillList"
@@ -52,7 +54,8 @@ def stock_intraday_sina(
     tqdm = get_tqdm()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url=url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url=url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json)
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)

--- a/akshare/stock/stock_ipo_summary_cninfo.py
+++ b/akshare/stock/stock_ipo_summary_cninfo.py
@@ -7,6 +7,7 @@ https://webapi.cninfo.com.cn/#/company
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -57,7 +58,8 @@ def stock_ipo_summary_cninfo(symbol: str = "600030") -> pd.DataFrame:
         "Referer": "https://webapi.cninfo.com.cn/",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame.from_dict(data_json["records"][0], orient="index").T
     temp_df.columns = [

--- a/akshare/stock/stock_new_cninfo.py
+++ b/akshare/stock/stock_new_cninfo.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/#/xinguList
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -53,7 +54,8 @@ def stock_new_gh_cninfo() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [
@@ -100,7 +102,8 @@ def stock_new_ipo_cninfo() -> pd.DataFrame:
         "timetype": "36",
         "market": "ALL",
     }
-    r = requests.post(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_profile_cninfo.py
+++ b/akshare/stock/stock_profile_cninfo.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/#/company
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -58,7 +59,8 @@ def stock_profile_cninfo(symbol: str = "600030") -> pd.DataFrame:
         "Referer": "http://webapi.cninfo.com.cn/",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     columns = [
         "公司名称",

--- a/akshare/stock/stock_rank_forecast.py
+++ b/akshare/stock/stock_rank_forecast.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/#/thematicStatistics?name=%E6%8A%95%E8%B5%84%E8%AF%8
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -56,7 +57,8 @@ def stock_rank_forecast_cninfo(date: str = "20230817") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     temp_df.columns = [

--- a/akshare/stock/stock_repurchase_em.py
+++ b/akshare/stock/stock_repurchase_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/gphg/hglist.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -27,13 +28,15 @@ def stock_repurchase_em() -> pd.DataFrame:
         "columns": "ALL",
         "source": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, int(total_page) + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock/stock_share_changes_cninfo.py
+++ b/akshare/stock/stock_share_changes_cninfo.py
@@ -7,6 +7,7 @@ http://webapi.cninfo.com.cn/api/stock/p_stock2215
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.datasets import get_ths_js
@@ -69,7 +70,8 @@ def stock_share_change_cninfo(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.post(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["records"])
     cols_map = {

--- a/akshare/stock/stock_share_hold.py
+++ b/akshare/stock/stock_share_hold.py
@@ -17,6 +17,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -51,7 +52,8 @@ def stock_share_hold_change_sse(symbol: str = "600000") -> pd.DataFrame:
         "Referer": "http://www.sse.com.cn/",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
     }
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     total_page = data_json["pageHelp"]["pageCount"]
     big_df = pd.DataFrame()
@@ -63,7 +65,8 @@ def stock_share_hold_change_sse(symbol: str = "600000") -> pd.DataFrame:
                 "pageHelp.endPage": page,
             }
         )
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"])
         big_df = pd.concat(objs=[big_df, temp_df], axis=0, ignore_index=True)
@@ -134,7 +137,8 @@ def stock_share_hold_change_szse(symbol: str = "全部") -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
     }
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_json = r.json()
     total_page = data_json[0]["metadata"]["pagecount"]
     big_df = pd.DataFrame()
@@ -144,7 +148,8 @@ def stock_share_hold_change_szse(symbol: str = "全部") -> pd.DataFrame:
                 "PAGENO": page,
             }
         )
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json[0]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], axis=0, ignore_index=True)
@@ -214,7 +219,8 @@ def stock_share_hold_change_bse(symbol: str = "430489") -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36",
     }
-    r = requests.get(url, headers=headers, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, params=params, timeout=timeout)
     data_text = r.text
     data_text = data_text.strip("null(").strip(")")
     data_json = json.loads(data_text)
@@ -226,7 +232,8 @@ def stock_share_hold_change_bse(symbol: str = "430489") -> pd.DataFrame:
                 "page": page,
             }
         )
-        r = requests.get(url, headers=headers, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, params=params, timeout=timeout)
         data_text = r.text
         data_text = data_text.strip("null(").strip(")")
         data_json = json.loads(data_text)

--- a/akshare/stock/stock_stop.py
+++ b/akshare/stock/stock_stop.py
@@ -7,6 +7,7 @@ https://quote.eastmoney.com/center/gridlist.html#staq_net_board
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_staq_net_stop() -> pd.DataFrame:
@@ -30,7 +31,8 @@ def stock_staq_net_stop() -> pd.DataFrame:
         "fields": "f12,f14",
         "_": "1622622663841",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock/stock_summary.py
+++ b/akshare/stock/stock_summary.py
@@ -12,6 +12,7 @@ from io import BytesIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -32,7 +33,8 @@ def stock_szse_summary(date: str = "20200619") -> pd.DataFrame:
         "txtQueryDate": "-".join([date[:4], date[4:6], date[6:]]),
         "random": "0.39339437497296137",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         temp_df = pd.read_excel(BytesIO(r.content), engine="openpyxl")
@@ -63,7 +65,8 @@ def stock_szse_area_summary(date: str = "202203") -> pd.DataFrame:
         "DATETIME": "-".join([date[:4], date[4:6]]),
         "random": "0.39339437497296137",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         temp_df = pd.read_excel(BytesIO(r.content), engine="openpyxl")
@@ -92,7 +95,8 @@ def stock_szse_sector_summary(symbol: str = "当月", date: str = "202303") -> p
     :rtype: pandas.DataFrame
     """
     url = "https://www.szse.cn/market/periodical/month/index.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     soup = BeautifulSoup(r.text, "lxml")
     tags_list = soup.find_all("div", attrs={"class": "g-container"})[1].find_all(
@@ -116,13 +120,16 @@ def stock_szse_sector_summary(symbol: str = "当月", date: str = "202303") -> p
     )
     date_format = "-".join([date[:4], date[4:]])
     url = f"http://www.szse.cn/market/periodical/month/{date_url_dict[date_format]}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "utf8"
     soup = BeautifulSoup(r.text, "lxml")
     url = [item for item in soup.find_all("a") if item.get_text() == "股票行业成交数据"][0]["href"]
 
     if symbol == "当月":
-        temp_df = pd.read_html(url, encoding="gbk")[0]
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(url, headers=headers, timeout=timeout)
+        temp_df = pd.read_html(BytesIO(res.content), encoding="gbk")[0]
         temp_df.columns = [
             "项目名称",
             "项目名称-英文",
@@ -135,7 +142,9 @@ def stock_szse_sector_summary(symbol: str = "当月", date: str = "202303") -> p
             "成交笔数-占总计",
         ]
     else:
-        temp_df = pd.read_html(url, encoding="gbk")[1]
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(url, headers=headers, timeout=timeout)
+        temp_df = pd.read_html(BytesIO(res.content), encoding="gbk")[1]
         temp_df.columns = [
             "项目名称",
             "项目名称-英文",
@@ -176,7 +185,8 @@ def stock_sse_summary() -> pd.DataFrame:
         "Referer": "http://www.sse.com.cn/",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]).T
     temp_df.reset_index(inplace=True)
@@ -221,7 +231,8 @@ def stock_sse_deal_daily(date: str = "20180117") -> pd.DataFrame:
             "Referer": "http://www.sse.com.cn/",
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"])
         temp_df = temp_df.T
@@ -310,7 +321,8 @@ def stock_sse_deal_daily(date: str = "20180117") -> pd.DataFrame:
             "Referer": "http://www.sse.com.cn/",
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"])
         temp_df = temp_df.T
@@ -464,7 +476,8 @@ def stock_sse_deal_daily(date: str = "20180117") -> pd.DataFrame:
             "Referer": "http://www.sse.com.cn/",
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"])
         temp_df = temp_df.T
@@ -533,7 +546,8 @@ def stock_sse_deal_daily(date: str = "20180117") -> pd.DataFrame:
             "Referer": "http://www.sse.com.cn/",
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"])
         temp_df = temp_df.T

--- a/akshare/stock/stock_us_famous.py
+++ b/akshare/stock/stock_us_famous.py
@@ -7,6 +7,7 @@ http://quote.eastmoney.com/center/gridlist.html#us_wellknown
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_us_famous_spot_em(symbol: str = "科技类") -> pd.DataFrame:
@@ -40,7 +41,8 @@ def stock_us_famous_spot_em(symbol: str = "科技类") -> pd.DataFrame:
         "fields": "f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f12,f13,f14,f15,f16,f17,f18,f20,f21,f23,f24,f25,f26,f22,f33,f11,f62,f128,f136,f115,f152",
         "_": "1631271634231",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = [

--- a/akshare/stock/stock_us_js.py
+++ b/akshare/stock/stock_us_js.py
@@ -6,6 +6,7 @@ Desc: 美股目标价 or 港股目标价
 https://www.ushknews.com/report.html
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -41,7 +42,8 @@ def stock_price_js(symbol: str = "us") -> pd.DataFrame:
         "x-app-id": "BNsiR9uq7yfW0LVz",
         "x-version": "1.0.0",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     json_data = r.json()
     temp_df = pd.DataFrame(json_data["data"]["list"])
     temp_df.columns = [

--- a/akshare/stock/stock_us_pink.py
+++ b/akshare/stock/stock_us_pink.py
@@ -8,6 +8,7 @@ https://quote.eastmoney.com/center/gridlist.html#us_pinksheet
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_us_pink_spot_em() -> pd.DataFrame:
@@ -32,7 +33,8 @@ def stock_us_pink_spot_em() -> pd.DataFrame:
         "f26,f22,f33,f11,f62,f128,f136,f115,f152",
         "_": "1631271634231",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = [

--- a/akshare/stock/stock_us_sina.py
+++ b/akshare/stock/stock_us_sina.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 from tqdm import tqdm
 
@@ -38,9 +39,12 @@ def __get_us_page_count() -> int:
     js_code.eval(js_hash_text)
     dict_list = js_code.call("d", us_js_decode)  # 执行js解密代码
     us_sina_stock_dict_payload.update({"page": "{}".format(page)})
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
         us_sina_stock_list_url.format(dict_list),
         params=us_sina_stock_dict_payload,
+        headers=headers,
+        timeout=timeout
     )
     data_json = json.loads(res.text[res.text.find("({") + 1: res.text.rfind(");")])
     if not isinstance(int(data_json["count"]) / 20, int):
@@ -71,9 +75,12 @@ def get_us_stock_name() -> pd.DataFrame:
         js_code.eval(js_hash_text)
         dict_list = js_code.call("d", us_js_decode)  # 执行js解密代码
         us_sina_stock_dict_payload.update({"page": "{}".format(page)})
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         res = requests.get(
             us_sina_stock_list_url.format(dict_list),
             params=us_sina_stock_dict_payload,
+            headers=headers,
+            timeout=timeout
         )
         data_json = json.loads(res.text[res.text.find("({") + 1: res.text.rfind(");")])
         big_df = pd.concat([big_df, pd.DataFrame(data_json["data"])], ignore_index=True)
@@ -100,9 +107,12 @@ def stock_us_spot() -> pd.DataFrame:
         js_code.eval(js_hash_text)
         dict_list = js_code.call("d", us_js_decode)  # 执行js解密代码
         us_sina_stock_dict_payload.update({"page": "{}".format(page)})
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         res = requests.get(
             us_sina_stock_list_url.format(dict_list),
             params=us_sina_stock_dict_payload,
+            headers=headers,
+            timeout=timeout
         )
         data_json = json.loads(res.text[res.text.find("({") + 1: res.text.rfind(");")])
         big_df = pd.concat([big_df, pd.DataFrame(data_json["data"])], ignore_index=True)
@@ -124,7 +134,8 @@ def stock_us_daily(symbol: str = "FB", adjust: str = "") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://finance.sina.com.cn/staticdata/us/{symbol}"
-    res = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(zh_js_decode)
     dict_list = js_code.call(
@@ -137,7 +148,8 @@ def stock_us_daily(symbol: str = "FB", adjust: str = "") -> pd.DataFrame:
     del data_df["date"]
     data_df = data_df.astype("float")
     url = us_sina_stock_hist_qfq_url.format(symbol)
-    res = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(url, headers=headers, timeout=timeout)
     qfq_factor_df = pd.DataFrame(eval(res.text.split("=")[1].split("\n")[0])["data"])
     qfq_factor_df.rename(
         columns={

--- a/akshare/stock/stock_weibo_nlp.py
+++ b/akshare/stock/stock_weibo_nlp.py
@@ -14,6 +14,7 @@ from typing import Dict
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_js_weibo_nlp_time() -> Dict:
@@ -41,7 +42,8 @@ def stock_js_weibo_nlp_time() -> Dict:
         "accept-language": "zh-CN,zh;q=0.9,en;q=0.8",
     }
 
-    r = requests.get(url, headers=headers, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, data=payload, timeout=timeout)
     return r.json()["data"]["timescale"]
 
 
@@ -76,7 +78,8 @@ def stock_js_weibo_report(time_period: str = "CNHOUR12") -> pd.DataFrame:
         'accept-language': 'zh-CN,zh;q=0.9,en;q=0.8'
     }
 
-    r = requests.get(url, params=payload, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=payload, headers=headers, timeout=timeout)
     temp_df = pd.DataFrame(r.json()["data"])
     temp_df['rate'] = pd.to_numeric(temp_df['rate'])
     return temp_df

--- a/akshare/stock/stock_xq.py
+++ b/akshare/stock/stock_xq.py
@@ -10,6 +10,7 @@ import re
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_individual_spot_xq(
@@ -31,7 +32,8 @@ def stock_individual_spot_xq(
         "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/78.0.3904.108 Safari/537.36"
     }
-    session.get(url="https://xueqiu.com", headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    session.get(url="https://xueqiu.com", headers=headers, timeout=timeout)
     url = f"https://stock.xueqiu.com/v5/stock/quote.json?symbol={symbol}&extend=detail"
     r = session.get(url, headers=headers, timeout=timeout)
     column_name_map = {

--- a/akshare/stock/stock_zh_a_sina.py
+++ b/akshare/stock/stock_zh_a_sina.py
@@ -12,6 +12,7 @@ from akshare.utils import demjson
 from py_mini_racer import py_mini_racer
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 from akshare.stock.cons import (
@@ -33,7 +34,8 @@ def _get_zh_a_page_count() -> int:
     :return: 需要采集的股票总页数
     :rtype: int
     """
-    res = requests.get(zh_sina_a_stock_count_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(zh_sina_a_stock_count_url, headers=headers, timeout=timeout)
     page_count = int(re.findall(re.compile(r"\d+"), res.text)[0]) / 80
     if isinstance(page_count, int):
         return page_count
@@ -55,8 +57,9 @@ def stock_zh_a_spot() -> pd.DataFrame:
             range(1, page_count + 1), leave=False, desc="Please wait for a moment"
     ):
         zh_sina_stock_payload_copy.update({"page": page})
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         r = requests.get(
-            zh_sina_a_stock_url, params=zh_sina_stock_payload_copy
+            zh_sina_a_stock_url, params=zh_sina_stock_payload_copy, headers=headers, timeout=timeout
         )
         data_json = demjson.decode(r.text)
         big_df = pd.concat(
@@ -149,7 +152,8 @@ def stock_zh_a_daily(
 
     def _fq_factor(method: str) -> pd.DataFrame:
         if method == "hfq":
-            r = requests.get(zh_sina_a_stock_hfq_url.format(symbol))
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(zh_sina_a_stock_hfq_url.format(symbol), headers=headers, timeout=timeout)
             hfq_factor_df = pd.DataFrame(
                 eval(r.text.split("=")[1].split("\n")[0])["data"]
             )
@@ -161,7 +165,8 @@ def stock_zh_a_daily(
             hfq_factor_df.reset_index(inplace=True)
             return hfq_factor_df
         else:
-            r = requests.get(zh_sina_a_stock_qfq_url.format(symbol))
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(zh_sina_a_stock_qfq_url.format(symbol), headers=headers, timeout=timeout)
             qfq_factor_df = pd.DataFrame(
                 eval(r.text.split("=")[1].split("\n")[0])["data"]
             )
@@ -176,7 +181,8 @@ def stock_zh_a_daily(
     if adjust in ("hfq-factor", "qfq-factor"):
         return _fq_factor(adjust.split("-")[0])
 
-    r = requests.get(zh_sina_a_stock_hist_url.format(symbol))
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(zh_sina_a_stock_hist_url.format(symbol), headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)
     dict_list = js_code.call(
@@ -195,7 +201,8 @@ def stock_zh_a_daily(
     except:
         pass
     data_df = data_df.astype("float")
-    r = requests.get(zh_sina_a_stock_amount_url.format(symbol, symbol))
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(zh_sina_a_stock_amount_url.format(symbol, symbol), headers=headers, timeout=timeout)
     amount_data_json = demjson.decode(
         r.text[r.text.find("["): r.text.rfind("]") + 1]
     )
@@ -243,7 +250,8 @@ def stock_zh_a_daily(
         temp_df['date'] = pd.to_datetime(temp_df['date'], errors="coerce").dt.date
         return temp_df
     if adjust == "hfq":
-        res = requests.get(zh_sina_a_stock_hfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_a_stock_hfq_url.format(symbol), headers=headers, timeout=timeout)
         hfq_factor_df = pd.DataFrame(
             eval(res.text.split("=")[1].split("\n")[0])["data"]
         )
@@ -287,7 +295,8 @@ def stock_zh_a_daily(
         return temp_df
 
     if adjust == "qfq":
-        res = requests.get(zh_sina_a_stock_qfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_a_stock_qfq_url.format(symbol), headers=headers, timeout=timeout)
         qfq_factor_df = pd.DataFrame(
             eval(res.text.split("=")[1].split("\n")[0])["data"]
         )
@@ -348,7 +357,8 @@ def stock_zh_a_cdr_daily(
     :return: specific data
     :rtype: pandas.DataFrame
     """
-    res = requests.get(zh_sina_a_stock_hist_url.format(symbol))
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(zh_sina_a_stock_hist_url.format(symbol), headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)
     dict_list = js_code.call(
@@ -390,7 +400,8 @@ def stock_zh_a_minute(
         "ma": "no",
         "datalen": "1970",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     try:
         data_json = json.loads(data_text.split("=(")[1].split(");")[0])
@@ -403,7 +414,8 @@ def stock_zh_a_minute(
             "ma": "no",
             "datalen": "1970",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = json.loads(data_text.split("=(")[1].split(");")[0])
         temp_df = pd.DataFrame(data_json).iloc[:, :6]

--- a/akshare/stock/stock_zh_a_special.py
+++ b/akshare/stock/stock_zh_a_special.py
@@ -12,6 +12,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_zh_a_st_em() -> pd.DataFrame:
@@ -35,7 +36,8 @@ def stock_zh_a_st_em() -> pd.DataFrame:
         'fields': 'f2,f3,f4,f5,f6,f7,f8,f9,f10,f12,f13,f14,f15,f16,f17,f18,f20,f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152',
         '_': '1631107510188',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['data']['diff'])
     temp_df.reset_index(inplace=True)
@@ -127,7 +129,8 @@ def stock_zh_a_new_em() -> pd.DataFrame:
         'fields': 'f2,f3,f4,f5,f6,f7,f8,f9,f10,f12,f13,f14,f15,f16,f17,f18,f20,f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152',
         '_': '1631107510188',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['data']['diff'])
     temp_df.reset_index(inplace=True)
@@ -219,7 +222,8 @@ def stock_zh_a_stop_em() -> pd.DataFrame:
         'fields': 'f2,f3,f4,f5,f6,f7,f8,f9,f10,f12,f13,f14,f15,f16,f17,f18,f20,f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152',
         '_': '1631107510188',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['data']['diff'])
     temp_df.reset_index(inplace=True)
@@ -299,7 +303,8 @@ def stock_zh_a_new() -> pd.DataFrame:
     """
     url = "http://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getHQNodeStockCount"
     params = {"node": "new_stock"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     total_page = math.ceil(int(r.json()) / 80)
     url = "http://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getHQNodeData"
     big_df = pd.DataFrame()
@@ -313,7 +318,8 @@ def stock_zh_a_new() -> pd.DataFrame:
             "symbol": "",
             "_s_r_a": "page",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         r.encoding = "gb2312"
         data_json = r.json()
         temp_df = pd.DataFrame(data_json)

--- a/akshare/stock/stock_zh_a_tick_tx.py
+++ b/akshare/stock/stock_zh_a_tick_tx.py
@@ -10,6 +10,7 @@ import warnings
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_zh_a_tick_tx_js(symbol: str = "sz000001") -> pd.DataFrame:
@@ -33,7 +34,8 @@ def stock_zh_a_tick_tx_js(symbol: str = "sz000001") -> pd.DataFrame:
                 "c": symbol,
                 "p": page,
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             text_data = r.text
             temp_df = (
                 pd.DataFrame(eval(text_data[text_data.find("["):])[1].split("|"))

--- a/akshare/stock/stock_zh_ah_tx.py
+++ b/akshare/stock/stock_zh_ah_tx.py
@@ -9,6 +9,7 @@ import random
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock.cons import (
     hk_url,
@@ -30,7 +31,8 @@ def _get_zh_stock_ah_page_count() -> int:
     """
     hk_payload_copy = hk_payload.copy()
     hk_payload_copy.update({"reqPage": 1})
-    r = requests.get(hk_url, params=hk_payload_copy, headers=hk_headers)
+    hk_headers, timeout = get_headers_and_timeout(locals().get('hk_headers', {}), locals().get('timeout', None))
+    r = requests.get(hk_url, params=hk_payload_copy, headers=hk_headers, timeout=timeout)
     data_json = demjson.decode(
         r.text[r.text.find("{"): r.text.rfind("}") + 1]
     )
@@ -50,7 +52,8 @@ def stock_zh_ah_spot() -> pd.DataFrame:
     tqdm = get_tqdm()
     for i in tqdm(range(0, page_count), leave=False):
         hk_payload.update({"reqPage": i})
-        r = requests.get(hk_url, params=hk_payload, headers=hk_headers)
+        hk_headers, timeout = get_headers_and_timeout(locals().get('hk_headers', {}), locals().get('timeout', None))
+        r = requests.get(hk_url, params=hk_payload, headers=hk_headers, timeout=timeout)
         data_json = demjson.decode(
             r.text[r.text.find("{"): r.text.rfind("}") + 1]
         )
@@ -122,7 +125,8 @@ def stock_zh_ah_name() -> pd.DataFrame:
     tqdm = get_tqdm()
     for i in tqdm(range(0, page_count), leave=False):
         hk_payload.update({"reqPage": i})
-        r = requests.get(hk_url, params=hk_payload, headers=hk_headers)
+        hk_headers, timeout = get_headers_and_timeout(locals().get('hk_headers', {}), locals().get('timeout', None))
+        r = requests.get(hk_url, params=hk_payload, headers=hk_headers, timeout=timeout)
         data_json = demjson.decode(
             r.text[r.text.find("{"): r.text.rfind("}") + 1]
         )
@@ -210,16 +214,20 @@ def stock_zh_ah_daily(
                 "Referer": "http://gu.qq.com/hk01033/gp",
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36",
             }
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
             r = requests.get(
                 url="http://web.ifzq.gtimg.cn/appstock/app/kline/kline",
                 params=hk_stock_payload_copy,
                 headers=headers,
+                timeout=timeout
             )
         else:
+            hk_stock_headers, timeout = get_headers_and_timeout(locals().get('hk_stock_headers', {}), locals().get('timeout', None))
             r = requests.get(
                 url="https://web.ifzq.gtimg.cn/appstock/app/hkfqkline/get",
                 params=hk_stock_payload_copy,
                 headers=hk_stock_headers,
+                timeout=timeout
             )
         data_json = demjson.decode(
             r.text[r.text.find("{"): r.text.rfind("}") + 1]

--- a/akshare/stock/stock_zh_kcb_report.py
+++ b/akshare/stock/stock_zh_kcb_report.py
@@ -7,6 +7,7 @@ http://data.eastmoney.com/notices/kcb.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -27,7 +28,8 @@ def _stock_zh_kcb_report_em_page() -> int:
         "f_node": "0",
         "s_node": "0",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = int(
         int(data_json["data"]["total_hits"]) / int(data_json["data"]["page_size"])
@@ -61,7 +63,8 @@ def stock_zh_kcb_report_em(from_page: int = 1, to_page: int = 100) -> pd.DataFra
             "f_node": "0",
             "s_node": "0",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [

--- a/akshare/stock/stock_zh_kcb_sina.py
+++ b/akshare/stock/stock_zh_kcb_sina.py
@@ -10,6 +10,7 @@ import re
 from akshare.utils import demjson
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 from akshare.stock.cons import (
@@ -30,7 +31,8 @@ def get_zh_kcb_page_count() -> int:
     :return: 所有股票的总页数
     :rtype: int
     """
-    res = requests.get(zh_sina_kcb_stock_count_url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    res = requests.get(zh_sina_kcb_stock_count_url, headers=headers, timeout=timeout)
     page_count = int(re.findall(re.compile(r"\d+"), res.text)[0]) / 80
     if isinstance(page_count, int):
         return page_count
@@ -51,7 +53,8 @@ def stock_zh_kcb_spot() -> pd.DataFrame:
     for page in tqdm(range(1, page_count + 1), leave=False):
         zh_sina_stock_payload_copy.update({"page": page})
         zh_sina_stock_payload_copy.update({"_s_r_a": "page"})
-        res = requests.get(zh_sina_kcb_stock_url, params=zh_sina_stock_payload_copy)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_kcb_stock_url, params=zh_sina_stock_payload_copy, headers=headers, timeout=timeout)
         data_json = demjson.decode(res.text)
         big_df = pd.concat([big_df, pd.DataFrame(data_json)], ignore_index=True)
     big_df.columns = [
@@ -128,10 +131,13 @@ def stock_zh_kcb_daily(symbol: str = "sh688399", adjust: str = "") -> pd.DataFra
     :return: 科创板股票的历史行情数据
     :rtype: pandas.DataFrame
     """
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     res = requests.get(
         zh_sina_kcb_stock_hist_url.format(
             symbol, datetime.datetime.now().strftime("%Y_%m_%d"), symbol
-        )
+        ),
+        headers=headers,
+        timeout=timeout
     )
     data_json = demjson.decode(res.text[res.text.find("[") : res.text.rfind("]") + 1])
     data_df = pd.DataFrame(data_json)
@@ -139,7 +145,8 @@ def stock_zh_kcb_daily(symbol: str = "sh688399", adjust: str = "") -> pd.DataFra
     data_df.index.name = "date"
     del data_df["d"]
 
-    r = requests.get(zh_sina_kcb_stock_amount_url.format(symbol, symbol))
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(zh_sina_kcb_stock_amount_url.format(symbol, symbol), headers=headers, timeout=timeout)
     amount_data_json = demjson.decode(r.text[r.text.find("[") : r.text.rfind("]") + 1])
     amount_data_df = pd.DataFrame(amount_data_json)
     amount_data_df.index = pd.to_datetime(amount_data_df.date)
@@ -177,7 +184,8 @@ def stock_zh_kcb_daily(symbol: str = "sh688399", adjust: str = "") -> pd.DataFra
         return temp_df
 
     if adjust == "hfq":
-        res = requests.get(zh_sina_kcb_stock_hfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_kcb_stock_hfq_url.format(symbol), headers=headers, timeout=timeout)
         hfq_factor_df = pd.DataFrame(
             eval(res.text.split("=")[1].split("\n")[0])["data"]
         )
@@ -208,7 +216,8 @@ def stock_zh_kcb_daily(symbol: str = "sh688399", adjust: str = "") -> pd.DataFra
         return temp_df
 
     if adjust == "qfq":
-        res = requests.get(zh_sina_kcb_stock_qfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_kcb_stock_qfq_url.format(symbol), headers=headers, timeout=timeout)
         qfq_factor_df = pd.DataFrame(
             eval(res.text.split("=")[1].split("\n")[0])["data"]
         )
@@ -239,7 +248,8 @@ def stock_zh_kcb_daily(symbol: str = "sh688399", adjust: str = "") -> pd.DataFra
         return temp_df
 
     if adjust == "hfq-factor":
-        res = requests.get(zh_sina_kcb_stock_hfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_kcb_stock_hfq_url.format(symbol), headers=headers, timeout=timeout)
         hfq_factor_df = pd.DataFrame(
             eval(res.text.split("=")[1].split("\n")[0])["data"]
         )
@@ -251,7 +261,8 @@ def stock_zh_kcb_daily(symbol: str = "sh688399", adjust: str = "") -> pd.DataFra
         return hfq_factor_df
 
     if adjust == "qfq-factor":
-        res = requests.get(zh_sina_kcb_stock_qfq_url.format(symbol))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        res = requests.get(zh_sina_kcb_stock_qfq_url.format(symbol), headers=headers, timeout=timeout)
         qfq_factor_df = pd.DataFrame(
             eval(res.text.split("=")[1].split("\n")[0])["data"]
         )

--- a/akshare/stock_feature/stock_a_below_net_asset_statistics.py
+++ b/akshare/stock_feature/stock_a_below_net_asset_statistics.py
@@ -7,6 +7,7 @@ https://www.legulegu.com/stockdata/below-net-asset-statistics
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_a_below_net_asset_statistics(symbol: str = "全部A股") -> pd.DataFrame:
@@ -29,7 +30,8 @@ def stock_a_below_net_asset_statistics(symbol: str = "全部A股") -> pd.DataFra
         "marketId": symbol_map[symbol],
         "token": "325843825a2745a2a8f9b9e3355cb864",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
     temp_df["date"] = pd.to_datetime(temp_df["date"], unit="ms").dt.date

--- a/akshare/stock_feature/stock_a_high_low.py
+++ b/akshare/stock_feature/stock_a_high_low.py
@@ -7,6 +7,7 @@ https://www.legulegu.com/stockdata/high-low-statistics
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_a_high_low_statistics(symbol: str = "all") -> pd.DataFrame:
@@ -19,7 +20,8 @@ def stock_a_high_low_statistics(symbol: str = "all") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://www.legulegu.com/stockdata/member-ship/get-high-low-statistics/{symbol}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
     del temp_df["indexCode"]

--- a/akshare/stock_feature/stock_a_indicator.py
+++ b/akshare/stock_feature/stock_a_indicator.py
@@ -11,6 +11,7 @@ from hashlib import md5
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -21,7 +22,8 @@ def get_cookie_csrf(url: str = "") -> dict:
     :return: 指定市场的市盈率数据
     :rtype: pandas.DataFrame
     """
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     csrf_tag = soup.find(name="meta", attrs={"name": "_csrf"})
     csrf_token = csrf_tag.attrs["content"]
@@ -54,7 +56,8 @@ def stock_a_indicator_lg(symbol: str = "002174") -> pd.DataFrame:
     """
     if symbol == "all":
         url = "https://legulegu.com/stocklist"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         soup = BeautifulSoup(r.text, features="lxml")
         node_list = soup.find_all(attrs={"class": "col-xs-6"})
         href_list = [item.find("a")["href"] for item in node_list]
@@ -69,10 +72,12 @@ def stock_a_indicator_lg(symbol: str = "002174") -> pd.DataFrame:
         url = "https://legulegu.com/api/s/base-info/"
         token = get_token_lg()
         params = {"token": token, "id": symbol}
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
         r = requests.post(
             url,
             params=params,
             **get_cookie_csrf(url="https://legulegu.com/"),
+            timeout=timeout
         )
         temp_json = r.json()
         temp_df = pd.DataFrame(
@@ -102,7 +107,8 @@ def stock_hk_indicator_eniu(
     """
     if indicator == "港股":
         url = "https://eniu.com/static/data/stock_list.json"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json)
         temp_df = temp_df[temp_df["stock_id"].str.contains("hk")]
@@ -118,7 +124,8 @@ def stock_hk_indicator_eniu(
         url = f"https://eniu.com/chart/roeh/{symbol}"
     else:
         url = f"https://eniu.com/chart/marketvalueh/{symbol}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)
     return temp_df

--- a/akshare/stock_feature/stock_a_pe_and_pb.py
+++ b/akshare/stock_feature/stock_a_pe_and_pb.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.stock_feature.stock_a_indicator import get_cookie_csrf
@@ -343,7 +344,8 @@ def stock_market_pe_lg(symbol: str = "深证") -> pd.DataFrame:
             "创业板": "https://legulegu.com/stockdata/cybPE",
         }
         params = {"token": token, "marketId": symbol_map[symbol]}
-        r = requests.get(url, params=params, **get_cookie_csrf(url=url_map[symbol]))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, **get_cookie_csrf(url=url_map[symbol]), headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df["date"] = (
@@ -367,7 +369,8 @@ def stock_market_pe_lg(symbol: str = "深证") -> pd.DataFrame:
     else:
         url = "https://legulegu.com/api/stockdata/get-ke-chuang-ban-pe"
         params = {"token": token}
-        r = requests.get(url, params=params, **get_cookie_csrf(url="https://legulegu.com/stockdata/ke-chuang-ban-pe"))
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, **get_cookie_csrf(url="https://legulegu.com/stockdata/ke-chuang-ban-pe"), timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         temp_df["date"] = (
@@ -415,7 +418,8 @@ def stock_index_pe_lg(symbol: str = "沪深300") -> pd.DataFrame:
     }
     url = "https://legulegu.com/api/stockdata/index-basic-pe"
     params = {"token": token, "indexCode": symbol_map[symbol]}
-    r = requests.get(url, params=params, **get_cookie_csrf(url="https://legulegu.com/stockdata/sz50-ttm-lyr"))
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, **get_cookie_csrf(url="https://legulegu.com/stockdata/sz50-ttm-lyr"), timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["date"] = (
@@ -466,7 +470,8 @@ def stock_market_pb_lg(symbol: str = "上证") -> pd.DataFrame:
         "科创版": "https://legulegu.com/stockdata/ke-chuang-ban-pb",
     }
     params = {"token": token, "indexCode": symbol_map[symbol]}
-    r = requests.get(url, params=params, **get_cookie_csrf(url=url_map[symbol]))
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, **get_cookie_csrf(url=url_map[symbol]), timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["date"] = (
@@ -518,7 +523,8 @@ def stock_index_pb_lg(symbol: str = "上证50") -> pd.DataFrame:
     }
     url = "https://legulegu.com/api/stockdata/index-basic-pb"
     params = {"token": token, "indexCode": symbol_map[symbol]}
-    r = requests.get(url, params=params, **get_cookie_csrf(url="https://legulegu.com/stockdata/zz500-ttm-lyr"))
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, **get_cookie_csrf(url="https://legulegu.com/stockdata/zz500-ttm-lyr"), timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["date"] = (

--- a/akshare/stock_feature/stock_account_em.py
+++ b/akshare/stock_feature/stock_account_em.py
@@ -8,6 +8,7 @@ http://data.eastmoney.com/cjsj/gpkhsj.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_account_statistics_em() -> pd.DataFrame:
@@ -32,7 +33,8 @@ def stock_account_statistics_em() -> pd.DataFrame:
         'pageNumber': '1',
         '_': '1640749656405',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result']['data'])
     temp_df.columns = [

--- a/akshare/stock_feature/stock_all_pb.py
+++ b/akshare/stock_feature/stock_all_pb.py
@@ -7,6 +7,7 @@ https://www.legulegu.com/stockdata/all-pb
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock_feature.stock_a_indicator import get_token_lg, get_cookie_csrf
 
@@ -23,10 +24,12 @@ def stock_a_all_pb() -> pd.DataFrame:
         "marketId": "ALL",
         "token": get_token_lg(),
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
-        **get_cookie_csrf(url="https://legulegu.com/stockdata/all-pb")
+        **get_cookie_csrf(url="https://legulegu.com/stockdata/all-pb"),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])

--- a/akshare/stock_feature/stock_analyst_em.py
+++ b/akshare/stock_feature/stock_analyst_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/invest/invest/list.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -36,13 +37,15 @@ def stock_analyst_rank_em(year: str = "2023") -> pd.DataFrame:
         "distinct": "ANALYST_CODE",
         "limit": "top100",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         data_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, data_df], ignore_index=True)
@@ -130,7 +133,8 @@ def stock_analyst_detail_em(
             "filter": f'(ANALYST_CODE="{analyst_id}")',
             "_": "1675744438197",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]['data'])
         temp_df.reset_index(inplace=True)
@@ -183,7 +187,8 @@ def stock_analyst_detail_em(
             "filter": f'(ANALYST_CODE="{analyst_id}")',
             "_": "1675744438197",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]['data'])
         temp_df.reset_index(inplace=True)
@@ -229,7 +234,8 @@ def stock_analyst_detail_em(
             "client": "WEB",
             "_": "1675744438200",
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(
            data_json['result']['data']

--- a/akshare/stock_feature/stock_board_concept_ths.py
+++ b/akshare/stock_feature/stock_board_concept_ths.py
@@ -12,6 +12,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from py_mini_racer import py_mini_racer
 from tqdm import tqdm
@@ -40,7 +41,8 @@ def stock_board_concept_graph_ths(symbol: str = "通用航空") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     new_list = []
     for col in temp_df.columns:
@@ -89,7 +91,8 @@ def stock_board_concept_name_ths() -> pd.DataFrame:
         "Chrome/89.0.4389.90 Safari/537.36",
         "Cookie": f"v={v_code}",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     total_page = soup.find(name="span", attrs={"class": "page_info"}).text.split("/")[1]
     big_df = pd.DataFrame()
@@ -104,7 +107,8 @@ def stock_board_concept_name_ths() -> pd.DataFrame:
             "Chrome/89.0.4389.90 Safari/537.36",
             "Cookie": f"v={v_code}",
         }
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         soup = BeautifulSoup(r.text, features="lxml")
         url_list = []
         for item in (
@@ -126,7 +130,8 @@ def stock_board_concept_name_ths() -> pd.DataFrame:
 
     # 处理遗漏的板块
     url = "https://q.10jqka.com.cn/gn/detail/code/301558/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     need_list = [
         item.find_all("a") for item in soup.find_all(attrs={"class": "cate_group"})
@@ -192,7 +197,8 @@ def stock_board_concept_cons_ths(symbol: str = "小米概念") -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"https://q.10jqka.com.cn/gn/detail/field/264648/order/desc/page/1/ajax/1/code/{symbol}"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     try:
         page_num = int(
@@ -209,7 +215,8 @@ def stock_board_concept_cons_ths(symbol: str = "小米概念") -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"https://q.10jqka.com.cn/gn/detail/field/264648/order/desc/page/{page}/ajax/1/code/{symbol}"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
     big_df.rename(
@@ -248,7 +255,8 @@ def stock_board_concept_info_ths(symbol: str = "阿里巴巴概念") -> pd.DataF
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     name_list = [
         item.text
@@ -282,7 +290,8 @@ def stock_board_concept_hist_ths(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(symbol_url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(symbol_url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     symbol_code = soup.find("div", attrs={"class": "board-hq"}).find("span").text
     big_df = pd.DataFrame()
@@ -295,7 +304,8 @@ def stock_board_concept_hist_ths(
             "Referer": "https://q.10jqka.com.cn",
             "Host": "d.10jqka.com.cn",
         }
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_text = r.text
         try:
             demjson.decode(data_text[data_text.find("{") : -1])
@@ -375,12 +385,14 @@ def stock_board_cons_ths(symbol: str = "301558") -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"https://q.10jqka.com.cn/thshy/detail/field/199112/order/desc/page/1/ajax/1/code/{symbol}"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     url_flag = "thshy"
     if soup.find("td", attrs={"colspan": "14"}):
         url = f"https://q.10jqka.com.cn/gn/detail/field/199112/order/desc/page/1/ajax/1/code/{symbol}"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         soup = BeautifulSoup(r.text, "lxml")
         url_flag = "gn"
     try:
@@ -396,7 +408,8 @@ def stock_board_cons_ths(symbol: str = "301558") -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"https://q.10jqka.com.cn/{url_flag}/detail/field/199112/order/desc/page/{page}/ajax/1/code/{symbol}"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.rename(

--- a/akshare/stock_feature/stock_board_industry_ths.py
+++ b/akshare/stock_feature/stock_board_industry_ths.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from py_mini_racer import py_mini_racer
 from tqdm import tqdm
@@ -381,7 +382,8 @@ def stock_board_industry_cons_ths(symbol: str = "半导体及元件") -> pd.Data
         "Cookie": f"v={v_code}",
     }
     url = f"http://q.10jqka.com.cn/thshy/detail/field/199112/order/desc/page/1/ajax/1/code/{symbol}"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         page_num = int(soup.find_all("a", attrs={"class": "changePage"})[-1]["page"])
@@ -395,7 +397,8 @@ def stock_board_industry_cons_ths(symbol: str = "半导体及元件") -> pd.Data
             "Cookie": f"v={v_code}",
         }
         url = f"http://q.10jqka.com.cn/thshy/detail/field/199112/order/desc/page/{page}/ajax/1/code/{symbol}"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
 
@@ -431,7 +434,8 @@ def stock_board_industry_info_ths(symbol: str = "半导体及元件") -> pd.Data
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     name_list = [
         item.text.strip()
@@ -476,7 +480,8 @@ def stock_board_industry_index_ths(
             "Referer": "http://q.10jqka.com.cn",
             "Host": "d.10jqka.com.cn",
         }
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_text = r.text
         try:
             demjson.decode(data_text[data_text.find("{") : -1])
@@ -557,7 +562,8 @@ def stock_ipo_benefit_ths() -> pd.DataFrame:
         "hexin-v": v_code,
     }
     url = f"http://data.10jqka.com.cn/ipo/syg/field/invest/order/desc/page/1/ajax/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     page_num = soup.find("span", attrs={"class": "page_info"}).text.split("/")[1]
     big_df = pd.DataFrame()
@@ -569,7 +575,8 @@ def stock_ipo_benefit_ths() -> pd.DataFrame:
             "Cookie": f"v={v_code}",
             "hexin-v": v_code,
         }
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
 
@@ -610,13 +617,15 @@ def stock_board_industry_summary_ths() -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://q.10jqka.com.cn/thshy/index/field/199112/order/desc/page/1/ajax/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     page_num = soup.find("span", attrs={"class": "page_info"}).text.split("/")[1]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, int(page_num) + 1), leave=False):
         url = f"http://q.10jqka.com.cn/thshy/index/field/199112/order/desc/page/{page}/ajax/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
 

--- a/akshare/stock_feature/stock_buffett_index_lg.py
+++ b/akshare/stock_feature/stock_buffett_index_lg.py
@@ -7,6 +7,7 @@ https://legulegu.com/stockdata/marketcap-gdp
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock_feature.stock_a_indicator import get_token_lg, get_cookie_csrf
 
@@ -21,10 +22,12 @@ def stock_buffett_index_lg() -> pd.DataFrame:
     token = get_token_lg()
     url = "https://legulegu.com/api/stockdata/marketcap-gdp/get-marketcap-gdp"
     params = {"token": token}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
-        **get_cookie_csrf(url="https://legulegu.com/stockdata/marketcap-gdp")
+        **get_cookie_csrf(url="https://legulegu.com/stockdata/marketcap-gdp"),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])

--- a/akshare/stock_feature/stock_classify_sina.py
+++ b/akshare/stock_feature/stock_classify_sina.py
@@ -9,6 +9,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -20,7 +21,8 @@ def stock_classify_board() -> dict:
     :rtype: dict
     """
     url = "http://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getHQNodes"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     big_dict = {}
     class_name_list = [
@@ -62,7 +64,8 @@ def stock_classify_sina(symbol: str = "热门概念") -> pd.DataFrame:
     ):
         url = "http://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getHQNodeStockCount"
         params = {"node": stock_classify_board_dict[symbol]["code"][num]}
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         page_num = math.ceil(int(r.json()) / 80)
         url = "http://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/Market_Center.getHQNodeData"
         big_df = pd.DataFrame()
@@ -76,7 +79,8 @@ def stock_classify_sina(symbol: str = "热门概念") -> pd.DataFrame:
                 "symbol": "",
                 "_s_r_a": "init",
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json)
             big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_comment_em.py
+++ b/akshare/stock_feature/stock_comment_em.py
@@ -10,6 +10,7 @@ import time
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -33,14 +34,16 @@ def stock_comment_em() -> pd.DataFrame:
         "filter": "",
         "token": "894050c76af8597a853f5b408b759f5d",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -133,7 +136,8 @@ def stock_comment_detail_zlkp_jgcyd_em(symbol: str = "600000") -> pd.DataFrame:
         "sortTypes": "-1",
         "_": "1655387358195",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df = temp_df[["TRADE_DATE", "ORG_PARTICIPATE"]]
@@ -159,7 +163,8 @@ def stock_comment_detail_zhpj_lspf_em(symbol: str = "600000") -> pd.DataFrame:
     data_json = None
     while try_count:
         try:
-            r = requests.get(url)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, headers=headers, timeout=timeout)
             data_json = r.json()
             break
         except requests.exceptions.JSONDecodeError:
@@ -201,7 +206,8 @@ def stock_comment_detail_scrd_focus_em(symbol: str = "600000") -> pd.DataFrame:
     data_json = None
     while try_count:
         try:
-            r = requests.get(url)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, headers=headers, timeout=timeout)
             data_json = r.json()
             break
         except requests.exceptions.JSONDecodeError:
@@ -245,7 +251,8 @@ def stock_comment_detail_scrd_desire_em(
     data_json = None
     while try_count:
         try:
-            r = requests.get(url)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, headers=headers, timeout=timeout)
             data_json = r.json()
             break
         except requests.exceptions.JSONDecodeError:
@@ -294,7 +301,8 @@ def stock_comment_detail_scrd_desire_daily_em(
     data_json = None
     while try_count:
         try:
-            r = requests.get(url)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, headers=headers, timeout=timeout)
             data_json = r.json()
             break
         except requests.exceptions.JSONDecodeError:
@@ -342,7 +350,8 @@ def stock_comment_detail_scrd_cost_em(symbol: str = "600000") -> pd.DataFrame:
     data_json = None
     while try_count:
         try:
-            r = requests.get(url)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, headers=headers, timeout=timeout)
             data_json = r.json()
             break
         except requests.exceptions.JSONDecodeError:

--- a/akshare/stock_feature/stock_congestion_lg.py
+++ b/akshare/stock_feature/stock_congestion_lg.py
@@ -7,6 +7,7 @@ https://legulegu.com/stockdata/ashares-congestion
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock_feature.stock_a_indicator import get_token_lg, get_cookie_csrf
 
@@ -21,10 +22,12 @@ def stock_a_congestion_lg() -> pd.DataFrame:
     url = "https://legulegu.com/api/stockdata/ashares-congestion"
     token = get_token_lg()
     params = {"token": token}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
-        **get_cookie_csrf(url="https://legulegu.com/stockdata/ashares-congestion")
+        **get_cookie_csrf(url="https://legulegu.com/stockdata/ashares-congestion"),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["items"])

--- a/akshare/stock_feature/stock_cyq_em.py
+++ b/akshare/stock_feature/stock_cyq_em.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.stock_feature.stock_hist_em import code_id_map_em
@@ -235,7 +236,8 @@ def stock_cyq_em(symbol: str = "000001", adjust: str = "") -> pd.DataFrame:
         "lmt": "210",
         "cb": "quote_jp1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.text.strip("quote_jp1(").strip(");")
     data_json = json.loads(data_json)
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])

--- a/akshare/stock_feature/stock_disclosure_cninfo.py
+++ b/akshare/stock_feature/stock_disclosure_cninfo.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -74,7 +75,8 @@ def __get_stock_json(symbol: str = "沪深京") -> dict:
         url = "http://www.cninfo.com.cn/new/data/fund_stock.json"
     elif symbol == "债券":
         url = "http://www.cninfo.com.cn/new/data/bond_stock.json"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     text_json = r.json()
     temp_df = pd.DataFrame([item for item in text_json["stockList"]])
     return dict(zip(temp_df["code"], temp_df["orgId"]))
@@ -142,14 +144,16 @@ def stock_zh_a_disclosure_report_cninfo(
         "sortType": "",
         "isHLtitle": "true",
     }
-    r = requests.post(url, params=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=payload, headers=headers, timeout=timeout)
     text_json = r.json()
     page_num = math.ceil(int(text_json["totalAnnouncement"]) / 30)
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(1, page_num + 1), leave=False):
         payload.update({"pageNum": page})
-        r = requests.post(url, data=payload)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, data=payload, headers=headers, timeout=timeout)
         text_json = r.json()
         temp_df = pd.DataFrame(text_json["announcements"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -232,14 +236,16 @@ def stock_zh_a_disclosure_relation_cninfo(
         "sortType": "",
         "isHLtitle": "true",
     }
-    r = requests.post(url, data=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, data=payload, headers=headers, timeout=timeout)
     text_json = r.json()
     page_num = math.ceil(int(text_json["totalAnnouncement"]) / 30)
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(1, page_num + 1), leave=False):
         payload.update({"pageNum": page})
-        r = requests.post(url, data=payload)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, data=payload, headers=headers, timeout=timeout)
         text_json = r.json()
         temp_df = pd.DataFrame(text_json["announcements"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_dxsyl_em.py
+++ b/akshare/stock_feature/stock_dxsyl_em.py
@@ -10,6 +10,7 @@ https://data.eastmoney.com/xg/xg/default_2.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -35,14 +36,16 @@ def stock_dxsyl_em() -> pd.DataFrame:
         "client": "WEB",
         "filter": """((APPLY_DATE>'2010-01-01')(|@APPLY_DATE="NULL"))((LISTING_DATE>'2010-01-01')(|@LISTING_DATE="NULL"))(TRADE_MARKET_CODE!="069001017")""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -137,14 +140,16 @@ def stock_xgsglb_em(symbol: str = "全部股票") -> pd.DataFrame:
             "source": "NEEQSELECT",
             "client": "WEB",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         tqdm = get_tqdm()
         for page in tqdm(range(1, 1 + int(total_page)), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -251,14 +256,16 @@ def stock_xgsglb_em(symbol: str = "全部股票") -> pd.DataFrame:
             "source": "WEB",
             "client": "WEB",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         tqdm = get_tqdm()
         for page in tqdm(range(1, total_page + 1), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_ebs_lg.py
+++ b/akshare/stock_feature/stock_ebs_lg.py
@@ -7,6 +7,7 @@ https://legulegu.com/stockdata/equity-bond-spread
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock_feature.stock_a_indicator import get_token_lg, get_cookie_csrf
 
@@ -21,10 +22,12 @@ def stock_ebs_lg() -> pd.DataFrame:
     url = "https://legulegu.com/api/stockdata/equity-bond-spread"
     token = get_token_lg()
     params = {"token": token, "code": "000300.SH"}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
-        **get_cookie_csrf(url="https://legulegu.com/stockdata/equity-bond-spread")
+        **get_cookie_csrf(url="https://legulegu.com/stockdata/equity-bond-spread"),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])

--- a/akshare/stock_feature/stock_esg_sina.py
+++ b/akshare/stock_feature/stock_esg_sina.py
@@ -10,6 +10,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -21,7 +22,8 @@ def stock_esg_msci_sina() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://global.finance.sina.com.cn/api/openapi.php/EsgService.getMsciEsgStocks?p=1&num=100"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = math.ceil(int(data_json["result"]["data"]["total"]) / 100)
     big_df = pd.DataFrame()
@@ -32,7 +34,8 @@ def stock_esg_msci_sina() -> pd.DataFrame:
             "Chrome/123.0.0.0 Safari/537.36",
         }
         url = f"https://global.finance.sina.com.cn/api/openapi.php/EsgService.getMsciEsgStocks?p={page}&num=100"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -111,7 +114,8 @@ def stock_esg_rft_sina() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://global.finance.sina.com.cn/api/openapi.php/EsgService.getRftEsgStocks?p=1&num=20000"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame(data_json["result"]["data"]["data"])
     big_df.rename(
@@ -175,13 +179,15 @@ def stock_esg_rate_sina() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://global.finance.sina.com.cn/api/openapi.php/EsgService.getEsgStocks?page=1&num=200"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = math.ceil(data_json["result"]["data"]["info"]["total"] / 200)
     big_df = pd.DataFrame()
     for page in tqdm(range(1, page_num + 1), leave=False):
         url = f"https://global.finance.sina.com.cn/api/openapi.php/EsgService.getEsgStocks?page={page}&num=200"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         data_json = r.json()
         stock_num = len(data_json["result"]["data"]["info"]["stocks"])
         for num in range(stock_num):
@@ -228,7 +234,8 @@ def stock_esg_zd_sina() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://global.finance.sina.com.cn/api/openapi.php/EsgService.getZdEsgStocks?p=1&num=20000"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame(data_json["result"]["data"]["data"])
     big_df.rename(
@@ -264,7 +271,8 @@ def stock_esg_hz_sina() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://global.finance.sina.com.cn/api/openapi.php/EsgService.getHzEsgStocks?p=1&num=20000"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame(data_json["result"]["data"]["data"])
     big_df.rename(

--- a/akshare/stock_feature/stock_fhps_em.py
+++ b/akshare/stock_feature/stock_fhps_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/yjfp/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -34,13 +35,15 @@ def stock_fhps_em(date: str = "20210630") -> pd.DataFrame:
         "filter": f"""(REPORT_DATE='{"-".join([date[:4], date[4:6], date[6:]])}')""",
     }
 
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_pages = int(data_json["result"]["pages"])
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_pages + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -142,13 +145,15 @@ def stock_fhps_detail_em(symbol: str = "300073") -> pd.DataFrame:
         "filter": f"""(SECURITY_CODE="{symbol}")""",
     }
 
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_pages = int(data_json["result"]["pages"])
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_pages + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_fhps_ths.py
+++ b/akshare/stock_feature/stock_fhps_ths.py
@@ -7,6 +7,7 @@ https://basic.10jqka.com.cn/new/603444/bonus.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_fhps_detail_ths(symbol: str = "603444") -> pd.DataFrame:
@@ -24,7 +25,8 @@ def stock_fhps_detail_ths(symbol: str = "603444") -> pd.DataFrame:
                       "AppleWebKit/537.36 (KHTML, like Gecko) "
                       "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gbk"
     temp_df = pd.read_html(r.text)[0]
     return temp_df

--- a/akshare/stock_feature/stock_fund_flow.py
+++ b/akshare/stock_feature/stock_fund_flow.py
@@ -16,6 +16,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from py_mini_racer import py_mini_racer
 from akshare.utils.tqdm import get_tqdm
@@ -64,7 +65,8 @@ def stock_fund_flow_individual(symbol: str = "即时") -> pd.DataFrame:
         "X-Requested-With": "XMLHttpRequest",
     }
     url = "http://data.10jqka.com.cn/funds/ggzjl/field/code/order/desc/ajax/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     raw_page = soup.find("span", attrs={"class": "page_info"}).text
     page_num = raw_page.split("/")[1]
@@ -98,7 +100,8 @@ def stock_fund_flow_individual(symbol: str = "即时") -> pd.DataFrame:
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36",
             "X-Requested-With": "XMLHttpRequest",
         }
-        r = requests.get(url.format(page), headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url.format(page), timeout=timeout, headers=headers)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
 
@@ -160,7 +163,8 @@ def stock_fund_flow_concept(symbol: str = "即时") -> pd.DataFrame:
     url = (
         "http://data.10jqka.com.cn/funds/gnzjl/field/tradezdf/order/desc/ajax/1/free/1/"
     )
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     raw_page = soup.find("span", attrs={"class": "page_info"}).text
     page_num = raw_page.split("/")[1]
@@ -194,7 +198,8 @@ def stock_fund_flow_concept(symbol: str = "即时") -> pd.DataFrame:
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36",
             "X-Requested-With": "XMLHttpRequest",
         }
-        r = requests.get(url.format(page), headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url.format(page), timeout=timeout, headers=headers)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
 
@@ -262,7 +267,8 @@ def stock_fund_flow_industry(symbol: str = "即时") -> pd.DataFrame:
     url = (
         "http://data.10jqka.com.cn/funds/hyzjl/field/tradezdf/order/desc/ajax/1/free/1/"
     )
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     raw_page = soup.find("span", attrs={"class": "page_info"}).text
     page_num = raw_page.split("/")[1]
@@ -296,7 +302,8 @@ def stock_fund_flow_industry(symbol: str = "即时") -> pd.DataFrame:
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36",
             "X-Requested-With": "XMLHttpRequest",
         }
-        r = requests.get(url.format(page), headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url.format(page), timeout=timeout, headers=headers)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
 
@@ -360,7 +367,8 @@ def stock_fund_flow_big_deal() -> pd.DataFrame:
         "X-Requested-With": "XMLHttpRequest",
     }
     url = "http://data.10jqka.com.cn/funds/ddzz/order/desc/ajax/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     raw_page = soup.find("span", attrs={"class": "page_info"}).text
     page_num = raw_page.split("/")[1]
@@ -385,7 +393,8 @@ def stock_fund_flow_big_deal() -> pd.DataFrame:
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36",
             "X-Requested-With": "XMLHttpRequest",
         }
-        r = requests.get(url.format(page), headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url.format(page), timeout=timeout, headers=headers)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
 

--- a/akshare/stock_feature/stock_gddh_em.py
+++ b/akshare/stock_feature/stock_gddh_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/gddh/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -29,7 +30,8 @@ def stock_gddh_em() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -39,7 +41,8 @@ def stock_gddh_em() -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], axis=0, ignore_index=True)

--- a/akshare/stock_feature/stock_gdfx_em.py
+++ b/akshare/stock_feature/stock_gdfx_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/gdfx/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -33,13 +34,15 @@ def stock_gdfx_free_holding_statistics_em(
         "client": "WEB",
         "filter": f"""(HOLDNUM_CHANGE_TYPE="001")(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -116,13 +119,15 @@ def stock_gdfx_holding_statistics_em(date: str = "20210930") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"""(HOLDNUM_CHANGE_TYPE="001")(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -200,13 +205,15 @@ def stock_gdfx_free_holding_change_em(date: str = "20210930") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -277,13 +284,15 @@ def stock_gdfx_holding_change_em(date: str = "20210930") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -353,7 +362,8 @@ def stock_gdfx_free_top_10_em(
         "code": f"{symbol.upper()}",
         "date": f"{'-'.join([date[:4], date[4:6], date[6:]])}",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["sdltgd"])
     temp_df.reset_index(inplace=True)
@@ -408,7 +418,8 @@ def stock_gdfx_top_10_em(
         "code": f"{symbol.upper()}",
         "date": f"{'-'.join([date[:4], date[4:6], date[6:]])}",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["sdgd"])
     temp_df.reset_index(inplace=True)
@@ -464,13 +475,15 @@ def stock_gdfx_free_holding_detail_em(date: str = "20210930") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -546,13 +559,15 @@ def stock_gdfx_holding_detail_em(date: str = "20230331", indicator: str = "个�
         "client": "WEB",
         "filter": f"""(HOLDER_NEWTYPE="{indicator}")(HOLDNUM_CHANGE_NAME="{symbol}")(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -624,13 +639,15 @@ def stock_gdfx_free_holding_analyse_em(date: str = "20230930") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -706,13 +723,15 @@ def stock_gdfx_holding_analyse_em(date: str = "20230331") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -797,13 +816,15 @@ def stock_gdfx_free_holding_teamwork_em(symbol: str = "社保") -> pd.DataFrame:
         "client": "WEB",
     }
     params.update(symbol_dict)
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -859,13 +880,15 @@ def stock_gdfx_holding_teamwork_em(symbol: str = "社保") -> pd.DataFrame:
         "client": "WEB",
     }
     params.update(symbol_dict)
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_gdhs.py
+++ b/akshare/stock_feature/stock_gdhs.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/gdhs/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from akshare.utils.tqdm import get_tqdm
 
 
@@ -45,7 +46,8 @@ def stock_zh_a_gdhs(symbol: str = "20230930") -> pd.DataFrame:
             "client": "WEB",
             'filter': f"(END_DATE='{symbol[:4] + '-' +  symbol[4:6] + '-' +  symbol[6:]}')",
         }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page_num = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -54,7 +56,8 @@ def stock_zh_a_gdhs(symbol: str = "20230930") -> pd.DataFrame:
         params.update({
             "pageNumber": page_num,
         })
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -135,7 +138,8 @@ def stock_zh_a_gdhs_detail_em(symbol: str = "000001") -> pd.DataFrame:
         'source': 'WEB',
         'client': 'WEB',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page_num = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -144,7 +148,8 @@ def stock_zh_a_gdhs_detail_em(symbol: str = "000001") -> pd.DataFrame:
         params.update({
             "pageNumber": page_num,
         })
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_gdzjc_em.py
+++ b/akshare/stock_feature/stock_gdzjc_em.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_ggcg_em(symbol: str = "全部") -> pd.DataFrame:
@@ -40,7 +41,8 @@ def stock_ggcg_em(symbol: str = "全部") -> pd.DataFrame:
         "filter": symbol_map[symbol],
     }
 
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -50,7 +52,8 @@ def stock_ggcg_em(symbol: str = "全部") -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_gpzy_em.py
+++ b/akshare/stock_feature/stock_gpzy_em.py
@@ -14,6 +14,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -36,7 +37,8 @@ def stock_gpzy_profile_em() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -100,13 +102,15 @@ def stock_gpzy_pledge_ratio_em(date: str = "20231020") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"(TRADE_DATE='{trade_date}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -176,7 +180,8 @@ def _get_page_num_gpzy_market_pledge_ratio_detail() -> int:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = math.ceil(int(data_json["result"]["count"]) / 500)
     return total_page
@@ -203,7 +208,8 @@ def stock_gpzy_pledge_ratio_detail_em() -> pd.DataFrame:
             "source": "WEB",
             "client": "WEB",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -302,7 +308,8 @@ def stock_gpzy_distribute_statistics_company_em() -> pd.DataFrame:
         "client": "WEB",
         "filter": '(PFORG_TYPE="证券")',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)
@@ -365,7 +372,8 @@ def stock_gpzy_distribute_statistics_bank_em() -> pd.DataFrame:
         "client": "WEB",
         "filter": '(PFORG_TYPE="银行")',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)
@@ -426,7 +434,8 @@ def stock_gpzy_industry_data_em() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock_feature/stock_gxl_lg.py
+++ b/akshare/stock_feature/stock_gxl_lg.py
@@ -7,6 +7,7 @@ https://legulegu.com/stockdata/guxilv
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock_feature.stock_a_indicator import get_token_lg, get_cookie_csrf
 
@@ -29,10 +30,12 @@ def stock_a_gxl_lg(symbol: str = "上证A股") -> pd.DataFrame:
     url = "https://legulegu.com/api/stockdata/guxilv"
     token = get_token_lg()
     params = {"token": token}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
-        **get_cookie_csrf(url="https://legulegu.com/stockdata/guxilv")
+        **get_cookie_csrf(url="https://legulegu.com/stockdata/guxilv"),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json[symbol_map[symbol]])
@@ -60,10 +63,12 @@ def stock_hk_gxl_lg() -> pd.DataFrame:
     url = "https://legulegu.com/api/stockdata/hs"
     token = get_token_lg()
     params = {"token": token, "indexCode": "HSI"}
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
-        **get_cookie_csrf(url="https://legulegu.com/stockdata/market/hk/dv/hsi")
+        **get_cookie_csrf(url="https://legulegu.com/stockdata/market/hk/dv/hsi"),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json)

--- a/akshare/stock_feature/stock_hist_em.py
+++ b/akshare/stock_feature/stock_hist_em.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_zh_a_spot_em() -> pd.DataFrame:
@@ -34,7 +35,9 @@ def stock_zh_a_spot_em() -> pd.DataFrame:
         "f20,f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return pd.DataFrame()
@@ -149,7 +152,9 @@ def stock_sh_a_spot_em() -> pd.DataFrame:
         "f24,f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return pd.DataFrame()
@@ -264,7 +269,9 @@ def stock_sz_a_spot_em() -> pd.DataFrame:
         "f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return pd.DataFrame()
@@ -379,7 +386,9 @@ def stock_bj_a_spot_em() -> pd.DataFrame:
         ",f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return pd.DataFrame()
@@ -495,7 +504,9 @@ def stock_new_a_spot_em() -> pd.DataFrame:
         "f25,f26,f22,f11,f62,f128,f136,f115,f152",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return pd.DataFrame()
@@ -615,7 +626,9 @@ def stock_cy_a_spot_em() -> pd.DataFrame:
         "f23,f24,f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return pd.DataFrame()
@@ -731,7 +744,9 @@ def stock_kc_a_spot_em() -> pd.DataFrame:
         "f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return pd.DataFrame()
@@ -846,7 +861,9 @@ def stock_zh_b_spot_em() -> pd.DataFrame:
         ",f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return pd.DataFrame()
@@ -961,7 +978,9 @@ def code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -982,7 +1001,9 @@ def code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -1002,7 +1023,9 @@ def code_id_map_em() -> dict:
         "fields": "f12",
         "_": "1623833739532",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["diff"]:
         return dict()
@@ -1053,7 +1076,8 @@ def stock_zh_a_hist(
         "end": end_date,
         "_": "1623766962675",
     }
-    r = requests.get(url, params=params, timeout=timeout)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, timeout=timeout, headers=headers)
     data_json = r.json()
     if not (data_json["data"] and data_json["data"]["klines"]):
         return pd.DataFrame()
@@ -1125,7 +1149,9 @@ def stock_zh_a_hist_min_em(
             "secid": f"{code_id_dict[symbol]}.{symbol}",
             "_": "1623766962675",
         }
-        r = requests.get(url, timeout=15, params=params)
+        timeout = 15
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, timeout=timeout, params=params, headers=headers)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["trends"]]
@@ -1165,7 +1191,9 @@ def stock_zh_a_hist_min_em(
             "end": "20500000",
             "_": "1630930917857",
         }
-        r = requests.get(url, timeout=15, params=params)
+        timeout = 15
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, timeout=timeout, params=params, headers=headers)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]
@@ -1244,7 +1272,9 @@ def stock_zh_a_hist_pre_min_em(
         "secid": f"{code_id_dict[symbol]}.{symbol}",
         "_": "1623766962675",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["trends"]])
     temp_df.columns = [
@@ -1294,7 +1324,9 @@ def stock_hk_spot_em() -> pd.DataFrame:
         "f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1624010056945",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = [
@@ -1384,7 +1416,9 @@ def stock_hk_main_board_spot_em() -> pd.DataFrame:
         "f21,f23,f24,f25,f22,f11,f62,f128,f136,f115,f152",
         "_": "1624010056945",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = [
@@ -1489,7 +1523,9 @@ def stock_hk_hist(
         "lmt": "1000000",
         "_": "1623766962675",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])
     if temp_df.empty:
@@ -1565,7 +1601,9 @@ def stock_hk_hist_min_em(
             "secid": f"116.{symbol}",
             "_": "1623766962675",
         }
-        r = requests.get(url, timeout=15, params=params)
+        timeout = 15
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, timeout=timeout, params=params, headers=headers)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["trends"]]
@@ -1605,7 +1643,9 @@ def stock_hk_hist_min_em(
             "end": "20500000",
             "_": "1630930917857",
         }
-        r = requests.get(url, timeout=15, params=params)
+        timeout = 15
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, timeout=timeout, params=params, headers=headers)
         data_json = r.json()
         temp_df = pd.DataFrame(
             [item.split(",") for item in data_json["data"]["klines"]]
@@ -1677,7 +1717,9 @@ def stock_us_spot_em() -> pd.DataFrame:
         "f21,f23,f24,f25,f26,f22,f33,f11,f62,f128,f136,f115,f152",
         "_": "1624010056945",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.columns = [
@@ -1792,7 +1834,9 @@ def stock_us_hist(
         "lmt": "1000000",
         "_": "1623766962675",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["klines"]:
         return pd.DataFrame()
@@ -1854,7 +1898,9 @@ def stock_us_hist_min_em(
         "secid": f"{symbol.split('.')[0]}.{symbol.split('.')[1]}",
         "_": "1623766962675",
     }
-    r = requests.get(url, timeout=15, params=params)
+    timeout = 15
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, timeout=timeout, params=params, headers=headers)
     data_json = r.json()
     if not data_json["data"]["trends"]:
         return pd.DataFrame()

--- a/akshare/stock_feature/stock_hist_tx.py
+++ b/akshare/stock_feature/stock_hist_tx.py
@@ -9,6 +9,7 @@ import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.index.index_stock_zh import get_tx_start_year
 from akshare.utils import demjson
@@ -55,7 +56,8 @@ def stock_zh_a_hist_tx(
             "param": f"{symbol},day,{year}-01-01,{year + 1}-12-31,640,{adjust}",
             "r": "0.8205512681390605",
         }
-        r = requests.get(url, params=params, timeout=timeout)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, timeout=timeout, headers=headers)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("={") + 1:])["data"][
             symbol

--- a/akshare/stock_feature/stock_hk_valuation_baidu.py
+++ b/akshare/stock_feature/stock_hk_valuation_baidu.py
@@ -6,6 +6,7 @@ Desc: 百度股市通-港股-财务报表-估值数据
 https://gushitong.baidu.com/stock/hk-06969
 """
 import http.client
+from akshare.request_config_manager import get_headers_and_timeout
 import json
 import urllib
 
@@ -36,8 +37,9 @@ def stock_hk_valuation_baidu(
         "skip_industry": "0",
         "finClientType": "pc",
     }
-    conn = http.client.HTTPSConnection("finance.pae.baidu.com")
-    conn.request("GET", f"/selfselect/openapi?{urllib.parse.urlencode(params)}")
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    conn = http.client.HTTPSConnection("finance.pae.baidu.com", timeout=timeout)
+    conn.request("GET", f"/selfselect/openapi?{urllib.parse.urlencode(params)}", headers=headers)
     r = conn.getresponse()
     data_json = json.loads(r.read())
     temp_df = pd.DataFrame(data_json["Result"]["chartInfo"][0]["body"])

--- a/akshare/stock_feature/stock_hot_xq.py
+++ b/akshare/stock_feature/stock_hot_xq.py
@@ -9,6 +9,7 @@ import math
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -54,7 +55,8 @@ def stock_hot_follow_xq(symbol: str = "最热门") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_num = data_json["data"]['count']
     total_page = math.ceil(total_num / 200)
@@ -62,7 +64,8 @@ def stock_hot_follow_xq(symbol: str = "最热门") -> pd.DataFrame:
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         try:
             temp_df = pd.DataFrame(data_json["data"]["list"])
@@ -139,7 +142,8 @@ def stock_hot_tweet_xq(symbol: str = "最热门") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_num = data_json["data"]['count']
     total_page = math.ceil(total_num / 200)
@@ -147,7 +151,8 @@ def stock_hot_tweet_xq(symbol: str = "最热门") -> pd.DataFrame:
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         try:
             temp_df = pd.DataFrame(data_json["data"]["list"])
@@ -224,7 +229,8 @@ def stock_hot_deal_xq(symbol: str = "最热门") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_num = data_json["data"]['count']
     total_page = math.ceil(total_num / 200)
@@ -232,7 +238,8 @@ def stock_hot_deal_xq(symbol: str = "最热门") -> pd.DataFrame:
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"page": page})
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         try:
             temp_df = pd.DataFrame(data_json["data"]["list"])

--- a/akshare/stock_feature/stock_hsgt_em.py
+++ b/akshare/stock_feature/stock_hsgt_em.py
@@ -9,6 +9,7 @@ https://data.eastmoney.com/hsgtcg/
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -37,7 +38,8 @@ def stock_hsgt_fund_flow_summary_em() -> pd.DataFrame:
         "client": "WEB",
         "_": "1669047266881",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [
@@ -111,7 +113,8 @@ def stock_hk_ggt_components_em() -> pd.DataFrame:
         "f25,f26,f22,f33,f11,f62,f128,f136,f115,f152",
         "_": "1639974456250",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["diff"])
     temp_df.reset_index(inplace=True)
@@ -186,7 +189,8 @@ def stock_hsgt_hold_stock_em(
     :rtype: pandas.DataFrame
     """
     url = "https://data.eastmoney.com/hsgtcg/list.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     date = (
         soup.find("div", attrs={"class": "title"})
@@ -228,13 +232,15 @@ def stock_hsgt_hold_stock_em(
         "client": "WEB",
         "filter": filter_str,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, page_num + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -376,13 +382,15 @@ def stock_hsgt_stock_statistics_em(
                 {"filter": f"""(INTERVAL_TYPE="1")(RN=1)(TRADE_DATE='{start_date}')"""}
             )
         url = "http://datacenter-web.eastmoney.com/api/data/v1/get"
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         for page in tqdm(range(1, int(total_page) + 1), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -470,13 +478,15 @@ def stock_hsgt_stock_statistics_em(
                 }
             )
         url = "http://datacenter-web.eastmoney.com/api/data/v1/get"
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         for page in tqdm(range(1, int(total_page) + 1), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -577,13 +587,15 @@ def stock_hsgt_stock_statistics_em(
                 }
             )
         url = "http://datacenter-web.eastmoney.com/api/data/v1/get"
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         for page in tqdm(range(1, int(total_page) + 1), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -683,13 +695,15 @@ def stock_hsgt_stock_statistics_em(
                 }
             )
         url = "http://datacenter-web.eastmoney.com/api/data/v1/get"
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         for page in tqdm(range(1, int(total_page) + 1), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -808,7 +822,8 @@ def stock_hsgt_institution_statistics_em(
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
         }
         url = "https://datacenter-web.eastmoney.com/api/data/v1/get"
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         temp_df.columns = [
@@ -866,13 +881,15 @@ def stock_hsgt_institution_statistics_em(
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
         }
         url = "https://datacenter-web.eastmoney.com/api/data/v1/get"
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         for page in tqdm(range(1, total_page + 1), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params, headers=headers)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -930,13 +947,15 @@ def stock_hsgt_institution_statistics_em(
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
         }
         url = "https://datacenter-web.eastmoney.com/api/data/v1/get"
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         for page in tqdm(range(1, total_page + 1), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params, headers=headers)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -994,13 +1013,15 @@ def stock_hsgt_institution_statistics_em(
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
         }
         url = "https://datacenter-web.eastmoney.com/api/data/v1/get"
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         total_page = data_json["result"]["pages"]
         big_df = pd.DataFrame()
         for page in tqdm(range(1, total_page + 1), leave=False):
             params.update({"pageNumber": page})
-            r = requests.get(url, params=params, headers=headers)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             data_json = r.json()
             temp_df = pd.DataFrame(data_json["result"]["data"])
             big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -1073,13 +1094,15 @@ def stock_hsgt_hist_em(symbol: str = "北向资金") -> pd.DataFrame:
         "client": "WEB",
         "filter": f'(MUTUAL_TYPE="00{symbol_map[symbol]}")',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, int(total_page) + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -1172,7 +1195,8 @@ def stock_hsgt_board_rank_em(
     :rtype: pandas.DataFrame
     """
     url = "https://data.eastmoney.com/hsgtcg/hy.html"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     current_date = soup.find(attrs={"id": "bkph_date"}).text.strip("（").strip("）")
     symbol_map = {
@@ -1202,7 +1226,8 @@ def stock_hsgt_board_rank_em(
         "client": "WEB",
         "filter": f"""(BOARD_TYPE="{symbol_map[symbol]}")(TRADE_DATE='{current_date}')(INTERVAL_TYPE="{indicator_map[indicator]}")""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)
@@ -1319,7 +1344,8 @@ def stock_hsgt_individual_em(stock: str = "002008") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"""(SECURITY_CODE="{stock}")(TRADE_DATE>='2020-07-25')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.rename(
@@ -1398,7 +1424,8 @@ def stock_hsgt_individual_detail_em(
         "client": "WEB",
         "filter": f"""(SECURITY_CODE="{symbol}")(MARKET_CODE="003")(HOLD_DATE>='{'-'.join([start_date[:4], start_date[4:6], start_date[6:]])}')(HOLD_DATE<='{'-'.join([end_date[:4], end_date[4:6], end_date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     try:
         data_json["result"]["pages"]
@@ -1408,13 +1435,15 @@ def stock_hsgt_individual_detail_em(
                 "filter": f"""(SECURITY_CODE="{symbol}")(MARKET_CODE="001")(HOLD_DATE>='{'-'.join([start_date[:4], start_date[4:6], start_date[6:]])}')(HOLD_DATE<='{'-'.join([end_date[:4], end_date[4:6], end_date[6:]])}')""",
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, int(total_page) + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_hsgt_exchange_rate.py
+++ b/akshare/stock_feature/stock_hsgt_exchange_rate.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_sgt_settlement_exchange_rate_szse() -> pd.DataFrame:
@@ -27,7 +28,8 @@ def stock_sgt_settlement_exchange_rate_szse() -> pd.DataFrame:
         'TABKEY': 'tab2',
         'random': '0.9184251620553985',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     import warnings
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
@@ -53,7 +55,8 @@ def stock_sgt_reference_exchange_rate_szse() -> pd.DataFrame:
         'TABKEY': 'tab1',
         'random': '0.9184251620553985',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     import warnings
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
@@ -91,7 +94,8 @@ def stock_sgt_reference_exchange_rate_sse() -> pd.DataFrame:
         'Referer': 'http://www.sse.com.cn/',
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36'
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result'])
     temp_df.rename(columns={
@@ -140,7 +144,8 @@ def stock_sgt_settlement_exchange_rate_sse() -> pd.DataFrame:
         'Referer': 'http://www.sse.com.cn/',
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36'
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result'])
     temp_df.rename(columns={

--- a/akshare/stock_feature/stock_hsgt_min_em.py
+++ b/akshare/stock_feature/stock_hsgt_min_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/hsgt/hsgtDetail/scgk.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_hsgt_fund_min_em(symbol: str = "北向资金") -> pd.DataFrame:
@@ -25,7 +26,8 @@ def stock_hsgt_fund_min_em(symbol: str = "北向资金") -> pd.DataFrame:
         'ut': 'b2884a393a59ad64002292a3e90d46a5',
         '_': '1707125786160'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
 
     if symbol == "南向资金":

--- a/akshare/stock_feature/stock_info.py
+++ b/akshare/stock_feature/stock_info.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -35,7 +36,8 @@ def stock_info_cjzc_em() -> pd.DataFrame:
     big_df = pd.DataFrame()
     for page in range(1, 3):
         params.update({"page_index": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["list"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -69,7 +71,8 @@ def stock_info_global_em() -> pd.DataFrame:
         "pageSize": "200",
         "req_trace": "1710315450384",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["fastNewsList"])
     temp_df = temp_df[["title", "summary", "showTime", "code"]]
@@ -106,7 +109,8 @@ def stock_info_global_sina() -> pd.DataFrame:
         "pagesize": "20",
         "type": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     time_list = [
         item["create_time"] for item in data_json["result"]["data"]["feed"]["list"]
@@ -134,7 +138,8 @@ def stock_info_global_futu() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)"
         " Chrome/111.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
 
     temp_df = pd.DataFrame(data_json["data"]["data"]["news"])
@@ -172,7 +177,8 @@ def stock_info_global_ths() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)"
         " Chrome/111.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["list"])
     temp_df = temp_df[["title", "digest", "rtime", "url"]]
@@ -203,7 +209,8 @@ def stock_info_global_cls(symbol: str = "全部") -> pd.DataFrame:
     """
     session = requests.session()
     url = "https://m.cls.cn/telegraph"
-    session.get(url)  # 获取 cookies
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    session.get(url, headers=headers, timeout=timeout)  # 获取 cookies
     params = {
         "refresh_type": "1",
         "rn": "10",
@@ -215,7 +222,7 @@ def stock_info_global_cls(symbol: str = "全部") -> pd.DataFrame:
     current_time = int(ts.timestamp())
     params.update({"last_time": current_time})
     url = "https://m.cls.cn/nodeapi/telegraphs"
-    r = session.get(url, params=params)
+    r = session.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["roll_data"])
     next_time = temp_df["modified_time"].values[-1]
@@ -223,7 +230,7 @@ def stock_info_global_cls(symbol: str = "全部") -> pd.DataFrame:
     big_df = temp_df.copy()
     while n < 15:
         params.update({"last_time": next_time})
-        r = session.get(url, params=params)
+        r = session.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["roll_data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -260,7 +267,8 @@ def stock_info_broker_sina(page: str = "1") -> pd.DataFrame:
     """
     url = "https://finance.sina.com.cn/roll/index.d.html?cid=221431"
     params = {"page": page}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     r.encoding = "utf-8"
     data_text = r.text
     soup = BeautifulSoup(data_text, features="lxml")

--- a/akshare/stock_feature/stock_inner_trade_xq.py
+++ b/akshare/stock_feature/stock_inner_trade_xq.py
@@ -7,6 +7,7 @@ https://xueqiu.com/hq/insider
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_inner_trade_xq() -> pd.DataFrame:
@@ -41,7 +42,8 @@ def stock_inner_trade_xq() -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
         "X-Requested-With": "XMLHttpRequest",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["items"])
     temp_df.columns = [

--- a/akshare/stock_feature/stock_irm_cninfo.py
+++ b/akshare/stock_feature/stock_irm_cninfo.py
@@ -7,6 +7,7 @@ https://irm.cninfo.com.cn/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -20,7 +21,8 @@ def _fetch_org_id(symbol: str = "000001") -> str:
     url = "https://irm.cninfo.com.cn/newircs/index/queryKeyboardInfo"
     params = {"_t": "1691144074"}
     data = {"keyWord": symbol}
-    r = requests.post(url, params=params, data=data)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, data=data, headers=headers, timeout=timeout)
     data_json = r.json()
     org_id = data_json["data"][0]["secid"]
     return org_id
@@ -46,14 +48,16 @@ def stock_irm_cninfo(symbol: str = "002594") -> pd.DataFrame:
         "startDay": "",
         "endDay": "",
     }
-    r = requests.post(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = int(data_json["totalPage"])
     total_page = 10 if total_page > 10 else total_page
     big_df = pd.DataFrame()
     for page in tqdm(range(1, 1 + total_page), leave=False):
         params.update({"pageNum": page})
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["rows"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -135,7 +139,8 @@ def stock_irm_ans_cninfo(symbol: str = "1513586704097333248") -> pd.DataFrame:
     """
     url = "https://irm.cninfo.com.cn/newircs/question/getQuestionDetail"
     params = {"questionId": symbol, "_t": "1691146921"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame.from_dict(data_json["data"], orient="index").T
     if "replyDate" not in temp_df.columns:

--- a/akshare/stock_feature/stock_jgdy_em.py
+++ b/akshare/stock_feature/stock_jgdy_em.py
@@ -9,6 +9,7 @@ http://data.eastmoney.com/jgdy/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -34,13 +35,15 @@ def stock_jgdy_tj_em(date: str = "20220101") -> pd.DataFrame:
         'client': 'WEB',
         'filter': f"""(NUMBERNEW="1")(IS_SOURCE="1")(RECEIVE_START_DATE>'{'-'.join([date[:4], date[4:6], date[6:]])}')"""
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json['result']['pages']
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page+1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']['data'])
         big_df = pd.concat([big_df, temp_df])
@@ -126,13 +129,15 @@ def stock_jgdy_detail_em(date: str = "20220101") -> pd.DataFrame:
         'client': 'WEB',
         'filter': f"""(IS_SOURCE="1")(RECEIVE_START_DATE>'{'-'.join([date[:4], date[4:6], date[6:]])}')"""
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json['result']['pages']
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page+1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']['data'])
         big_df = pd.concat([big_df, temp_df])

--- a/akshare/stock_feature/stock_lh_yybpm.py
+++ b/akshare/stock_feature/stock_lh_yybpm.py
@@ -6,6 +6,7 @@ Desc: 同花顺-数据中心-营业部排名
 http://data.10jqka.com.cn/market/longhu/
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 from tqdm import tqdm
 from bs4 import BeautifulSoup
@@ -22,14 +23,16 @@ def stock_lh_yyb_most() -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36"
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     page_str = soup.find("span", attrs={"class": "page_info"}).text
     total_page = int(page_str.split("/")[1]) + 1
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page)):
         url = f"http://data.10jqka.com.cn/ifmarket/lhbyyb/type/1/tab/sbcs/field/sbcs/sort/desc/page/{page}/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(r.text)[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.reset_index(inplace=True, drop=True)
@@ -47,14 +50,16 @@ def stock_lh_yyb_capital() -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36"
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     page_str = soup.find("span", attrs={"class": "page_info"}).text
     total_page = int(page_str.split("/")[1]) + 1
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page)):
         url = f"http://data.10jqka.com.cn/ifmarket/lhbyyb/type/1/tab/zjsl/field/zgczje/sort/desc/page/{page}/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(r.text)[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.reset_index(inplace=True, drop=True)
@@ -72,14 +77,16 @@ def stock_lh_yyb_control() -> pd.DataFrame:
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36"
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     page_str = soup.find("span", attrs={"class": "page_info"}).text
     total_page = int(page_str.split("/")[1]) + 1
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page)):
         url = f"http://data.10jqka.com.cn/ifmarket/lhbyyb/type/1/tab/btcz/field/xsjs/sort/desc/page/{page}/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(r.text)[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.reset_index(inplace=True, drop=True)

--- a/akshare/stock_feature/stock_lhb_em.py
+++ b/akshare/stock_feature/stock_lhb_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/stock/tradedetail.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -37,7 +38,8 @@ def stock_lhb_detail_em(
         "client": "WEB",
         "filter": f"(TRADE_DATE<='{end_date}')(TRADE_DATE>='{start_date}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page_num = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -47,7 +49,8 @@ def stock_lhb_detail_em(
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -153,7 +156,8 @@ def stock_lhb_stock_statistic_em(symbol: str = "近一月") -> pd.DataFrame:
         "client": "WEB",
         "filter": f'(STATISTICS_CYCLE="{symbol_map[symbol]}")',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)
@@ -240,7 +244,8 @@ def stock_lhb_jgmmtj_em(
         "client": "WEB",
         "filter": f"(TRADE_DATE>='{start_date}')(TRADE_DATE<='{end_date}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)
@@ -336,13 +341,15 @@ def stock_lhb_jgstatistic_em(symbol: str = "近一月") -> pd.DataFrame:
         "client": "WEB",
         "filter": f'(STATISTICSCYCLE="{symbol_map[symbol]}")',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -433,14 +440,16 @@ def stock_lhb_hyyyb_em(
         "client": "WEB",
         "filter": f"(ONLIST_DATE>='{start_date}')(ONLIST_DATE<='{end_date}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
 
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -511,13 +520,15 @@ def stock_lhb_yybph_em(symbol: str = "近一月") -> pd.DataFrame:
         "client": "WEB",
         "filter": f'(STATISTICSCYCLE="{symbol_map[symbol]}")',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -616,13 +627,15 @@ def stock_lhb_traderstatistic_em(symbol: str = "近一月") -> pd.DataFrame:
         "client": "WEB",
         "filter": f'(STATISTICSCYCLE="{symbol_map[symbol]}")',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -684,7 +697,8 @@ def stock_lhb_stock_detail_date_em(symbol: str = "600077") -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)
@@ -742,7 +756,8 @@ def stock_lhb_stock_detail_em(
         "client": "WEB",
         "_": "1647338693644",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock_feature/stock_lhb_sina.py
+++ b/akshare/stock_feature/stock_lhb_sina.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 from akshare.utils.tqdm import get_tqdm
@@ -26,7 +27,8 @@ def stock_lhb_detail_daily_sina(date: str = "20240222") -> pd.DataFrame:
     date = "-".join([date[:4], date[4:6], date[6:]])
     url = "https://vip.stock.finance.sina.com.cn/q/go.php/vInvestConsult/kind/lhb/index.phtml"
     params = {"tradedate": date}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     selected_html = soup.find(name="div", attrs={"class": "list"}).find_all(
         name="table", attrs={"class": "list_table"}
@@ -53,7 +55,8 @@ def _find_last_page(url: str = "https://vip.stock.finance.sina.com.cn/q/go.php/v
         "last": recent_day,
         "p": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         previous_page = int(soup.find_all(attrs={"class": "page"})[-2].text)
@@ -65,7 +68,8 @@ def _find_last_page(url: str = "https://vip.stock.finance.sina.com.cn/q/go.php/v
                 "last": recent_day,
                 "p": previous_page,
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             soup = BeautifulSoup(r.text, "lxml")
             last_page = int(soup.find_all(attrs={"class": "page"})[-2].text)
             if last_page != previous_page:
@@ -94,7 +98,8 @@ def stock_lhb_ggtj_sina(recent_day: str = "30") -> pd.DataFrame:
             "last": recent_day,
             "p": page,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0].iloc[0:, :]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df["股票代码"] = big_df["股票代码"].astype(str).str.zfill(6)
@@ -121,7 +126,8 @@ def stock_lhb_yytj_sina(recent_day: str = "5") -> pd.DataFrame:
             "last": "5",
             "p": page,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0].iloc[0:, :]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = ["营业部名称", "上榜次数", "累积购买额", "买入席位数", "累积卖出额", "卖出席位数", "买入前三股票"]
@@ -149,7 +155,8 @@ def stock_lhb_jgzz_sina(recent_day: str = "5") -> pd.DataFrame:
             "last": recent_day,
             "p": page,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0].iloc[0:, :]
         if temp_df.empty:
             continue
@@ -174,7 +181,8 @@ def stock_lhb_jgmx_sina() -> pd.DataFrame:
     params = {
         "p": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     try:
         last_page_num = int(soup.find_all(attrs={"class": "page"})[-2].text)
@@ -186,7 +194,8 @@ def stock_lhb_jgmx_sina() -> pd.DataFrame:
         params = {
             "p": page,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0].iloc[0:, :]
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
     big_df["股票代码"] = big_df["股票代码"].astype(str).str.zfill(6)

--- a/akshare/stock_feature/stock_market_legu.py
+++ b/akshare/stock_feature/stock_market_legu.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -21,7 +22,8 @@ def stock_market_activity_legu() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://legulegu.com/stockdata/market-activity"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df_one = temp_df.iloc[:, :2]
     temp_df_one.columns = ["item", "value"]

--- a/akshare/stock_feature/stock_pankou_em.py
+++ b/akshare/stock_feature/stock_pankou_em.py
@@ -7,6 +7,7 @@ https://quote.eastmoney.com/changes/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_changes_em(symbol: str = "大笔买入") -> pd.DataFrame:
@@ -52,7 +53,8 @@ def stock_changes_em(symbol: str = "大笔买入") -> pd.DataFrame:
         "dpt": "wzchanges",
         "_": "1624005264245",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["allstock"])
     temp_df["tm"] = pd.to_datetime(temp_df["tm"], format="%H%M%S").dt.time
@@ -93,7 +95,8 @@ def stock_board_change_em() -> pd.DataFrame:
         'pagesize': '5000',
         '_': '1671978840598',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     data_df = pd.DataFrame(data_json['data']['allbk'])
     data_df.columns = [

--- a/akshare/stock_feature/stock_qsjy_em.py
+++ b/akshare/stock_feature/stock_qsjy_em.py
@@ -7,6 +7,7 @@ http://data.eastmoney.com/other/qsjy.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_qsjy_em(date: str = "20200731") -> pd.DataFrame:
@@ -30,7 +31,8 @@ def stock_qsjy_em(date: str = "20200731") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"(END_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.columns = [

--- a/akshare/stock_feature/stock_report_em.py
+++ b/akshare/stock_feature/stock_report_em.py
@@ -13,6 +13,7 @@ https://data.eastmoney.com/bbsj/202003/xjll.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -40,7 +41,8 @@ def stock_zcfz_em(date: str = "20220331") -> pd.DataFrame:
         "filter": f"""(SECURITY_TYPE_CODE in ("058001001","058001008"))(TRADE_MARKET_CODE!="069001017")
         (REPORT_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -51,7 +53,8 @@ def stock_zcfz_em(date: str = "20220331") -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], join="outer", ignore_index=True)
@@ -181,7 +184,8 @@ def stock_lrb_em(date: str = "20081231") -> pd.DataFrame:
         "filter": f"""(SECURITY_TYPE_CODE in ("058001001","058001008"))(TRADE_MARKET_CODE!="069001017")
         (REPORT_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -192,7 +196,8 @@ def stock_lrb_em(date: str = "20081231") -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -317,7 +322,8 @@ def stock_xjll_em(date: str = "20220331") -> pd.DataFrame:
         "filter": f"""(SECURITY_TYPE_CODE in ("058001001","058001008"))(TRADE_MARKET_CODE!="069001017")
         (REPORT_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -328,7 +334,8 @@ def stock_xjll_em(date: str = "20220331") -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_research_report_em.py
+++ b/akshare/stock_feature/stock_research_report_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/report/stock.jshtml
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -37,7 +38,8 @@ def stock_research_report_em(symbol: str = "000001") -> pd.DataFrame:
         "pageNumber": "1",
         "_": "1692533168153",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["TotalPage"]
     big_df = pd.DataFrame()
@@ -50,7 +52,8 @@ def stock_research_report_em(symbol: str = "000001") -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         big_df = pd.concat([big_df, temp_df], axis=0, ignore_index=True)

--- a/akshare/stock_feature/stock_sns_sseinfo.py
+++ b/akshare/stock_feature/stock_sns_sseinfo.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -33,7 +34,8 @@ def _fetch_stock_uid() -> dict:
     code_list = list()
     for page in tqdm(range(1, 73), leave=False):
         data.update({"page": page})
-        r = requests.post(url, data=data)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, data=data, headers=headers, timeout=timeout)
         data_json = r.json()
         soup = BeautifulSoup(data_json["content"], "lxml")
         soup.find_all("a", attrs={"rel": "tag"})
@@ -73,12 +75,14 @@ def stock_sns_sseinfo(symbol: str = "603119") -> pd.DataFrame:
     warnings.warn("正在下载中")
     while True:
         params.update({"page": page})
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         if len(r.text) < 300:
             break
         else:
             page += 1
-        r = requests.post(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.post(url, params=params, headers=headers, timeout=timeout)
         soup = BeautifulSoup(r.text, "lxml")
         content_list = [
             item.get_text().strip()

--- a/akshare/stock_feature/stock_sse_margin.py
+++ b/akshare/stock_feature/stock_sse_margin.py
@@ -7,6 +7,7 @@ http://www.sse.com.cn/market/othersdata/margin/sum/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_margin_ratio_pa(date: str = "20231013") -> pd.DataFrame:
@@ -32,7 +33,8 @@ def stock_margin_ratio_pa(date: str = "20231013") -> pd.DataFrame:
         "requestId": "194055910e2075c03e25fabf6ffc5a7f",
         "channel": "pa18",
     }
-    r = requests.post(url, json=payload)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, json=payload, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"]["list"])
     temp_df.rename(
@@ -85,7 +87,8 @@ def stock_margin_sse(
         "Referer": "http://www.sse.com.cn/",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"])
     temp_df.columns = [
@@ -152,7 +155,8 @@ def stock_margin_detail_sse(date: str = "20230922") -> pd.DataFrame:
         "Referer": "http://www.sse.com.cn/",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"])
     temp_df.columns = [

--- a/akshare/stock_feature/stock_sy_em.py
+++ b/akshare/stock_feature/stock_sy_em.py
@@ -11,6 +11,7 @@ Desc: 东方财富网-数据中心-特色数据-商誉
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -33,7 +34,8 @@ def stock_sy_profile_em() -> pd.DataFrame:
         "filter": """((GOODWILL_STATE="1")( | IMPAIRMENT_STATE="1"))(TRADE_BOARD="all")""",
     }
 
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     data_df = pd.DataFrame(data_json["result"]["data"])
     data_df.columns = [
@@ -93,13 +95,15 @@ def stock_sy_yq_em(date: str = "20221231") -> pd.DataFrame:
         "reportName": "RPT_GOODWILL_STOCKPREDICT",
         "filter": f"""(REPORT_DATE='{"-".join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     total_page = int(data_json["result"]["pages"])
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -189,13 +193,15 @@ def stock_sy_jz_em(date: str = "20230331") -> pd.DataFrame:
         "reportName": "RPT_GOODWILL_STOCKDETAILS",
         "filter": f"""(REPORT_DATE='{"-".join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     total_page = int(data_json["result"]["pages"])
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -281,13 +287,15 @@ def stock_sy_em(date: str = "20231231") -> pd.DataFrame:
         "reportName": "RPT_GOODWILL_STOCKDETAILS",
         "filter": f"""(REPORT_DATE='{"-".join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     total_page = int(data_json["result"]["pages"])
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
@@ -359,13 +367,15 @@ def stock_sy_hy_em(date: str = "20231231") -> pd.DataFrame:
         "reportName": "RPT_GOODWILL_INDUSTATISTICS",
         "filter": f"""(REPORT_DATE='{"-".join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     total_page = int(data_json["result"]["pages"])
     for page in tqdm(range(1, total_page + 1), leave=False):
         params.update({"pageNumber": page})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_szse_margin.py
+++ b/akshare/stock_feature/stock_szse_margin.py
@@ -10,6 +10,7 @@ import warnings
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_margin_underlying_info_szse(date: str = "20221129") -> pd.DataFrame:
@@ -35,7 +36,8 @@ def stock_margin_underlying_info_szse(date: str = "20221129") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/88.0.4324.150 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         temp_df = pd.read_excel(r.content, engine="openpyxl", dtype={"证券代码": str})
@@ -64,7 +66,8 @@ def stock_margin_szse(date: str = "20240411") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/88.0.4324.150 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json[0]["data"])
     temp_df.columns = [
@@ -113,7 +116,8 @@ def stock_margin_detail_szse(date: str = "20230925") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/88.0.4324.150 Safari/537.36",
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         temp_df = pd.read_excel(r.content, engine="openpyxl", dtype={"证券代码": str})

--- a/akshare/stock_feature/stock_technology_ths.py
+++ b/akshare/stock_feature/stock_technology_ths.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from py_mini_racer import py_mini_racer
 
@@ -54,7 +55,8 @@ def stock_rank_cxg_ths(symbol: str = "创月新高") -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/cxg/board/{symbol_map[symbol]}/field/stockcode/order/asc/page/1/ajax/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -71,7 +73,8 @@ def stock_rank_cxg_ths(symbol: str = "创月新高") -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/cxg/board/{symbol_map[symbol]}/field/stockcode/order/asc/page/{page}/ajax/1/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -119,7 +122,8 @@ def stock_rank_cxd_ths(symbol: str = "创月新低") -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/cxd/board/{symbol_map[symbol]}/field/stockcode/order/asc/page/1/ajax/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -136,7 +140,8 @@ def stock_rank_cxd_ths(symbol: str = "创月新低") -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/cxd/board/{symbol_map[symbol]}/field/stockcode/order/asc/page/{page}/ajax/1/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -176,7 +181,8 @@ def stock_rank_lxsz_ths() -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/lxsz/field/lxts/order/desc/page/1/ajax/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -193,7 +199,8 @@ def stock_rank_lxsz_ths() -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/lxsz/field/lxts/order/desc/page/{page}/ajax/1/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -235,7 +242,8 @@ def stock_rank_lxxd_ths() -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/lxxd/field/lxts/order/desc/page/1/ajax/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -252,7 +260,8 @@ def stock_rank_lxxd_ths() -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/lxxd/field/lxts/order/desc/page/{page}/ajax/1/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -294,7 +303,8 @@ def stock_rank_cxfl_ths() -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/cxfl/field/count/order/desc/ajax/1/free/1/page/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -311,7 +321,8 @@ def stock_rank_cxfl_ths() -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/cxfl/field/count/order/desc/ajax/1/free/1/page/{page}/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -352,7 +363,8 @@ def stock_rank_cxsl_ths() -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/cxsl/field/count/order/desc/ajax/1/free/1/page/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -369,7 +381,8 @@ def stock_rank_cxsl_ths() -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/cxsl/field/count/order/desc/ajax/1/free/1/page/{page}/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -422,7 +435,8 @@ def stock_rank_xstp_ths(symbol: str = "500日均线") -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/xstp/board/{symbol_map[symbol]}/order/asc/ajax/1/free/1/page/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -439,7 +453,8 @@ def stock_rank_xstp_ths(symbol: str = "500日均线") -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/xstp/board/{symbol_map[symbol]}/order/asc/ajax/1/free/1/page/{page}/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -489,7 +504,8 @@ def stock_rank_xxtp_ths(symbol: str = "500日均线") -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/xxtp/board/{symbol_map[symbol]}/order/asc/ajax/1/free/1/page/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -506,7 +522,8 @@ def stock_rank_xxtp_ths(symbol: str = "500日均线") -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/xxtp/board/{symbol_map[symbol]}/order/asc/ajax/1/free/1/page/{page}/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -544,7 +561,8 @@ def stock_rank_ljqs_ths() -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/ljqs/field/count/order/desc/ajax/1/free/1/page/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -561,7 +579,8 @@ def stock_rank_ljqs_ths() -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/ljqs/field/count/order/desc/ajax/1/free/1/page/{page}/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -600,7 +619,8 @@ def stock_rank_ljqd_ths() -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/rank/ljqd/field/count/order/desc/ajax/1/free/1/page/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -617,7 +637,8 @@ def stock_rank_ljqd_ths() -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/rank/ljqd/field/count/order/desc/ajax/1/free/1/page/{page}/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
@@ -656,7 +677,8 @@ def stock_rank_xzjp_ths() -> pd.DataFrame:
         "Cookie": f"v={v_code}",
     }
     url = f"http://data.10jqka.com.cn/ajax/xzjp/field/DECLAREDATE/order/desc/ajax/1/free/1/"
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     try:
         total_page = soup.find(
@@ -673,7 +695,8 @@ def stock_rank_xzjp_ths() -> pd.DataFrame:
             "Cookie": f"v={v_code}",
         }
         url = f"http://data.10jqka.com.cn/ajax/xzjp/field/DECLAREDATE/order/desc/ajax/1/free/1/"
-        r = requests.get(url, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text), converters={"股票代码": str})[0]
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [

--- a/akshare/stock_feature/stock_tfp_em.py
+++ b/akshare/stock_feature/stock_tfp_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/tfpxx/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_tfp_em(date: str = "20221109") -> pd.DataFrame:
@@ -30,7 +31,8 @@ def stock_tfp_em(date: str = "20221109") -> pd.DataFrame:
         "client": "WEB",
         "filter": f"""(MARKET="全部")(DATETIME='{"-".join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock_feature/stock_three_report_em.py
+++ b/akshare/stock_feature/stock_three_report_em.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -24,7 +25,8 @@ def _stock_balance_sheet_by_report_ctype_em(symbol: str = "SH600519") -> str:
     """
     url = f"https://emweb.securities.eastmoney.com/PC_HSF10/NewFinanceAnalysis/Index"
     params = {"type": "web", "code": symbol.lower()}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, features="lxml")
     company_type = soup.find(attrs={"id": "hidctype"})["value"]
     return company_type
@@ -46,7 +48,8 @@ def stock_balance_sheet_by_report_em(symbol: str = "SH600519") -> pd.DataFrame:
         "reportDateType": "0",
         "code": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -63,7 +66,8 @@ def stock_balance_sheet_by_report_em(symbol: str = "SH600519") -> pd.DataFrame:
             "dates": item,
             "code": symbol,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         for col in temp_df.columns:
@@ -92,14 +96,16 @@ def stock_balance_sheet_by_yearly_em(symbol: str = "SH600036") -> pd.DataFrame:
         "reportDateType": "1",
         "code": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     try:
         temp_df = pd.DataFrame(data_json["data"])
     except:
         company_type = 3
         params.update({"companyType": company_type})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"], errors="coerce").dt.date
@@ -116,7 +122,8 @@ def stock_balance_sheet_by_yearly_em(symbol: str = "SH600036") -> pd.DataFrame:
             "dates": item,
             "code": symbol,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         for col in temp_df.columns:
@@ -145,7 +152,8 @@ def stock_profit_sheet_by_report_em(symbol: str = "SH600519") -> pd.DataFrame:
         "reportDateType": "0",
         "code": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -162,7 +170,8 @@ def stock_profit_sheet_by_report_em(symbol: str = "SH600519") -> pd.DataFrame:
             "code": symbol,
             "dates": item,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         for col in temp_df.columns:
@@ -191,7 +200,8 @@ def stock_profit_sheet_by_yearly_em(symbol: str = "SH600519") -> pd.DataFrame:
         "reportDateType": "1",
         "code": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -208,7 +218,8 @@ def stock_profit_sheet_by_yearly_em(symbol: str = "SH600519") -> pd.DataFrame:
             "dates": item,
             "code": symbol,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         for col in temp_df.columns:
@@ -239,7 +250,8 @@ def stock_profit_sheet_by_quarterly_em(
         "reportDateType": "2",
         "code": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -256,7 +268,8 @@ def stock_profit_sheet_by_quarterly_em(
             "dates": item,
             "code": symbol,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         for col in temp_df.columns:
@@ -287,7 +300,8 @@ def stock_cash_flow_sheet_by_report_em(
         "reportDateType": "0",
         "code": symbol,
     }
-    r = requests.get(url, params=params, timeout=10)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, timeout=10, headers=headers)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -304,7 +318,8 @@ def stock_cash_flow_sheet_by_report_em(
             "dates": item,
             "code": symbol,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         for col in temp_df.columns:
@@ -335,7 +350,8 @@ def stock_cash_flow_sheet_by_yearly_em(
         "reportDateType": "1",
         "code": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -352,7 +368,8 @@ def stock_cash_flow_sheet_by_yearly_em(
             "dates": item,
             "code": symbol,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         for col in temp_df.columns:
@@ -383,7 +400,8 @@ def stock_cash_flow_sheet_by_quarterly_em(
         "reportDateType": "2",
         "code": symbol,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -400,7 +418,8 @@ def stock_cash_flow_sheet_by_quarterly_em(
             "dates": item,
             "code": symbol,
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         for col in temp_df.columns:
@@ -435,7 +454,8 @@ def __get_report_date_list_delisted_em(symbol: str = "SZ000013") -> list:
         'client': 'PC',
         'v': '05767841728614413'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result']["data"])
     report_date_list = [item[0] for item in temp_df['REPORT_DATE'].str.split(" ")]
@@ -466,7 +486,8 @@ def stock_balance_sheet_by_report_delisted_em(symbol: str = "SZ000013") -> pd.Da
         'client': 'PC',
         'v': '05767841728614413'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result']["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -497,7 +518,8 @@ def stock_profit_sheet_by_report_delisted_em(symbol: str = "SZ000013") -> pd.Dat
         'client': 'PC',
         'v': '05767841728614413'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result']["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date
@@ -528,7 +550,8 @@ def stock_cash_flow_sheet_by_report_delisted_em(symbol: str = "SZ000013") -> pd.
         'client': 'PC',
         'v': '05767841728614413'
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result']["data"])
     temp_df["REPORT_DATE"] = pd.to_datetime(temp_df["REPORT_DATE"]).dt.date

--- a/akshare/stock_feature/stock_ttm_lyr.py
+++ b/akshare/stock_feature/stock_ttm_lyr.py
@@ -7,6 +7,7 @@ https://www.legulegu.com/stockdata/a-ttm-lyr
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.stock_feature.stock_a_indicator import get_token_lg, get_cookie_csrf
 
@@ -23,10 +24,12 @@ def stock_a_ttm_lyr() -> pd.DataFrame:
         "marketId": "5",
         "token": get_token_lg(),
     }
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
     r = requests.get(
         url,
         params=params,
-        **get_cookie_csrf(url="https://www.legulegu.com/stockdata/a-ttm-lyr")
+        **get_cookie_csrf(url="https://www.legulegu.com/stockdata/a-ttm-lyr"),
+        timeout=timeout
     )
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["data"])

--- a/akshare/stock_feature/stock_wencai.py
+++ b/akshare/stock_feature/stock_wencai.py
@@ -7,6 +7,7 @@ https://www.iwencai.com/unifiedwap/home/index
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -55,7 +56,8 @@ def stock_hot_rank_wc(date: str = "20230815") -> pd.DataFrame:
                 "page": page,
             }
         )
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["answer"]["components"][0]["data"]["datas"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_yjbb_em.py
+++ b/akshare/stock_feature/stock_yjbb_em.py
@@ -8,6 +8,7 @@ https://data.eastmoney.com/bbsj/202003/yjbb.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -30,7 +31,8 @@ def stock_yjbb_em(date: str = "20200331") -> pd.DataFrame:
         'columns': 'ALL',
         'filter': f"(REPORTDATE='{'-'.join([date[:4], date[4:6], date[6:]])}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -38,7 +40,8 @@ def stock_yjbb_em(date: str = "20200331") -> pd.DataFrame:
         params.update({
             'pageNumber': page,
         })
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_yjyg_cninfo.py
+++ b/akshare/stock_feature/stock_yjyg_cninfo.py
@@ -7,6 +7,7 @@ http://www.cninfo.com.cn/new/commonUrl?url=data/yypl
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_report_disclosure(
@@ -51,7 +52,8 @@ def stock_report_disclosure(
         "pagesize": "10000",
         "pagenum": "1",
     }
-    r = requests.post(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.post(url, params=params, headers=headers, timeout=timeout)
     text_json = r.json()
     temp_df = pd.DataFrame(text_json["prbookinfos"])
     temp_df.columns = [

--- a/akshare/stock_feature/stock_yjyg_em.py
+++ b/akshare/stock_feature/stock_yjyg_em.py
@@ -11,6 +11,7 @@ https://data.eastmoney.com/bbsj/202003/yysj.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -34,7 +35,8 @@ def stock_yjkb_em(date: str = "20211231") -> pd.DataFrame:
         "filter": f"""(SECURITY_TYPE_CODE in ("058001001","058001008"))(TRADE_MARKET_CODE!="069001017")
         (REPORT_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     total_page = data_json["result"]["pages"]
@@ -44,7 +46,8 @@ def stock_yjkb_em(date: str = "20211231") -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -151,7 +154,8 @@ def stock_yjyg_em(date: str = "20200331") -> pd.DataFrame:
         "columns": "ALL",
         "filter": f" (REPORT_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     big_df = pd.DataFrame()
     total_page = data_json["result"]["pages"]
@@ -161,7 +165,8 @@ def stock_yjyg_em(date: str = "20200331") -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -286,7 +291,8 @@ def stock_yysj_em(symbol: str = "沪深A股", date: str = "20200331") -> pd.Data
                 (REPORT_DATE='{'-'.join([date[:4], date[4:6], date[6:]])}')"""
             }
         )
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -296,7 +302,8 @@ def stock_yysj_em(symbol: str = "沪深A股", date: str = "20200331") -> pd.Data
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_yzxdr_em.py
+++ b/akshare/stock_feature/stock_yzxdr_em.py
@@ -7,6 +7,7 @@ http://data.eastmoney.com/yzxdr/
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 from akshare.utils import demjson
@@ -35,7 +36,8 @@ def stock_yzxdr_em(date: str = "20200930") -> pd.DataFrame:
         "filter": f"(enddate='{date}')",
         "rt": "53575609",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[data_text.find("{") : -1])
     total_pages = data_json["result"]["pages"]
@@ -53,7 +55,8 @@ def stock_yzxdr_em(date: str = "20200930") -> pd.DataFrame:
             "filter": f"(enddate='{date}')",
             "rt": "53575609",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_text = r.text
         data_json = demjson.decode(data_text[data_text.find("{") : -1])
         temp_df = pd.DataFrame(data_json["result"]["data"])

--- a/akshare/stock_feature/stock_zdhtmx_em.py
+++ b/akshare/stock_feature/stock_zdhtmx_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/zdht/mx.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -30,7 +31,8 @@ def stock_zdhtmx_em(
         "reportName": "RPTA_WEB_ZDHT_LIST",
         "filter": f"""(DIM_RDATE>='{"-".join([start_date[:4], start_date[4:6], start_date[6:]])}')(DIM_RDATE<='{"-".join([end_date[:4], end_date[4:6], end_date[6:]])}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -40,7 +42,8 @@ def stock_zdhtmx_em(
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], axis=0, ignore_index=True)

--- a/akshare/stock_feature/stock_zf_pg.py
+++ b/akshare/stock_feature/stock_zf_pg.py
@@ -11,6 +11,7 @@ https://data.eastmoney.com/xg/pg/
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -38,7 +39,8 @@ def stock_qbzf_em() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -49,7 +51,8 @@ def stock_qbzf_em() -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -119,7 +122,8 @@ def stock_pg_em() -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -130,7 +134,8 @@ def stock_pg_em() -> pd.DataFrame:
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)

--- a/akshare/stock_feature/stock_zh_valuation_baidu.py
+++ b/akshare/stock_feature/stock_zh_valuation_baidu.py
@@ -7,6 +7,7 @@ https://gushitong.baidu.com/stock/ab-002044
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_zh_valuation_baidu(
@@ -41,7 +42,8 @@ def stock_zh_valuation_baidu(
         "skip_industry": "1",
         "finClientType": "pc",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(
         data_json["Result"][0]["DisplayData"]["resultData"]["tplData"]["result"][

--- a/akshare/stock_feature/stock_zh_vote_baidu.py
+++ b/akshare/stock_feature/stock_zh_vote_baidu.py
@@ -6,6 +6,7 @@ Desc: 百度股市通- A 股或指数-股评-投票
 https://gushitong.baidu.com/index/ab-000001
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 
@@ -34,7 +35,8 @@ def stock_zh_vote_baidu(symbol: str = "000001", indicator: str = "指数") -> pd
     temp_list = []
     for item_period in ["day", "week", "month", "year"]:
         params.update({"select_type": item_period})
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_list.append(
             [

--- a/akshare/stock_feature/stock_ztb_em.py
+++ b/akshare/stock_feature/stock_ztb_em.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_zt_pool_em(date: str = "20231129") -> pd.DataFrame:
@@ -40,7 +41,8 @@ def stock_zt_pool_em(date: str = "20231129") -> pd.DataFrame:
         "date": date,
         "_": "1621590489736",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if data_json["data"] is None:
         return pd.DataFrame()
@@ -125,7 +127,8 @@ def stock_zt_pool_previous_em(date: str = "20240415") -> pd.DataFrame:
         "date": date,
         "_": "1621590489736",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if data_json["data"] is None:
         return pd.DataFrame()
@@ -201,7 +204,8 @@ def stock_zt_pool_strong_em(date: str = "20231129") -> pd.DataFrame:
         "date": date,
         "_": "1621590489736",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if data_json["data"] is None:
         return pd.DataFrame()
@@ -277,7 +281,8 @@ def stock_zt_pool_sub_new_em(date: str = "20231129") -> pd.DataFrame:
         "date": date,
         "_": "1621590489736",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if data_json["data"]["pool"] == 0:
         return pd.DataFrame()
@@ -363,7 +368,8 @@ def stock_zt_pool_zbgc_em(date: str = "20231129") -> pd.DataFrame:
         "date": date,
         "_": "1621590489736",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if data_json["data"] is None:
         return pd.DataFrame()
@@ -444,7 +450,8 @@ def stock_zt_pool_dtgc_em(date: str = "20231129") -> pd.DataFrame:
         "date": date,
         "_": "1621590489736",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if len(data_json["data"]["pool"]) == 0:
         return pd.DataFrame()

--- a/akshare/stock_fundamental/stock_finance.py
+++ b/akshare/stock_fundamental/stock_finance.py
@@ -15,6 +15,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
@@ -41,7 +42,8 @@ def stock_financial_report_sina(
         "page": "1",
         "num": "100",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     df_columns = [
         item["date_value"] for item in data_json["result"]["data"]["report_date"]
@@ -104,7 +106,8 @@ def stock_financial_abstract(symbol: str = "600004") -> pd.DataFrame:
         "page": "1",
         "num": "100",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     key_list = list(data_json["result"]["data"]["report_list"].keys())
     temp_df = pd.DataFrame(
@@ -186,7 +189,8 @@ def stock_financial_analysis_indicator(
     :rtype: pandas.DataFrame
     """
     url = f"https://money.finance.sina.com.cn/corp/go.php/vFD_FinancialGuideLine/stockid/{symbol}/ctrl/2020/displaytype/4.phtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     year_context = soup.find(attrs={"id": "con02-1"}).find("table").find_all("a")
     year_list = [item.text for item in year_context]
@@ -195,7 +199,8 @@ def stock_financial_analysis_indicator(
     out_df = pd.DataFrame()
     for year_item in tqdm(year_list, leave=False):
         url = f"https://money.finance.sina.com.cn/corp/go.php/vFD_FinancialGuideLine/stockid/{symbol}/ctrl/{year_item}/displaytype/4.phtml"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[12].iloc[:, :-1]
         temp_df.columns = temp_df.iloc[0, :]
         temp_df = temp_df.iloc[1:, :]
@@ -239,7 +244,8 @@ def stock_history_dividend() -> pd.DataFrame:
     """
     url = "http://vip.stock.finance.sina.com.cn/q/go.php/vInvestConsult/kind/lsfh/index.phtml"
     params = {"p": "1", "num": "5000"}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df["代码"] = temp_df["代码"].astype(str).str.zfill(6)
     temp_df.columns = ["代码", "名称", "上市日期", "累计股息", "年均股息", "分红次数", "融资总额", "融资次数", "详细"]
@@ -270,7 +276,8 @@ def stock_history_dividend_detail(
     """
     if indicator == "分红":
         url = f"http://vip.stock.finance.sina.com.cn/corp/go.php/vISSUE_ShareBonus/stockid/{symbol}.phtml"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[12]
         temp_df.columns = [item[2] for item in temp_df.columns.tolist()]
         temp_df.columns = [
@@ -307,7 +314,8 @@ def stock_history_dividend_detail(
                 "type": "1",
                 "end_date": date,
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             temp_df = pd.read_html(StringIO(r.text))[12]
             temp_df.columns = ["item", "value"]
             return temp_df
@@ -315,7 +323,8 @@ def stock_history_dividend_detail(
             return temp_df
     else:
         url = f"http://vip.stock.finance.sina.com.cn/corp/go.php/vISSUE_ShareBonus/stockid/{symbol}.phtml"
-        r = requests.get(url)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, headers=headers, timeout=timeout)
         temp_df = pd.read_html(StringIO(r.text))[13]
         temp_df.columns = [item[1] for item in temp_df.columns.tolist()]
         temp_df.columns = [
@@ -362,7 +371,8 @@ def stock_history_dividend_detail(
                 "type": "1",
                 "end_date": date,
             }
-            r = requests.get(url, params=params)
+            headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+            r = requests.get(url, params=params, headers=headers, timeout=timeout)
             temp_df = pd.read_html(StringIO(r.text))[12]
             temp_df.columns = ["item", "value"]
             return temp_df
@@ -380,7 +390,8 @@ def stock_ipo_info(stock: str = "600004") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://vip.stock.finance.sina.com.cn/corp/go.php/vISSUE_NewStock/stockid/{stock}.phtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[12]
     temp_df.columns = ["item", "value"]
     return temp_df
@@ -396,7 +407,8 @@ def stock_add_stock(symbol: str = "688166") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://vip.stock.finance.sina.com.cn/corp/go.php/vISSUE_AddStock/stockid/{symbol}.phtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[12]
     if temp_df.at[0, 0] == "对不起，暂时没有相关增发记录":
         raise f"股票 {symbol} 无增发记录"
@@ -421,7 +433,8 @@ def stock_restricted_release_queue_sina(symbol: str = "600000") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://vip.stock.finance.sina.com.cn/q/go.php/vInvestConsult/kind/xsjj/index.phtml?symbol={symbol}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df.columns = ["代码", "名称", "解禁日期", "解禁数量", "解禁股流通市值", "上市批次", "公告日期"]
     temp_df["解禁日期"] = pd.to_datetime(temp_df["解禁日期"], errors="coerce").dt.date
@@ -444,7 +457,8 @@ def stock_circulate_stock_holder(symbol: str = "600000") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://vip.stock.finance.sina.com.cn/corp/go.php/vCI_CirculateStockHolder/stockid/{symbol}.phtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[13].iloc[:, :5]
     temp_df.columns = [*range(5)]
     big_df = pd.DataFrame()
@@ -497,7 +511,8 @@ def stock_fund_stock_holder(symbol: str = "600004") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://vip.stock.finance.sina.com.cn/corp/go.php/vCI_FundStockHolder/stockid/{symbol}.phtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[13].iloc[:, :6]
     temp_df.columns = [*range(6)]
     big_df = pd.DataFrame()
@@ -547,7 +562,8 @@ def stock_main_stock_holder(stock: str = "600004") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"https://vip.stock.finance.sina.com.cn/corp/go.php/vCI_StockHolder/stockid/{stock}.phtml"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[13].iloc[:, :5]
     temp_df.columns = [*range(5)]
     big_df = pd.DataFrame()

--- a/akshare/stock_fundamental/stock_finance_hk.py
+++ b/akshare/stock_fundamental/stock_finance_hk.py
@@ -7,6 +7,7 @@ https://emweb.securities.eastmoney.com/PC_HKF10/FinancialAnalysis/index?type=web
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_financial_hk_report_em(
@@ -34,7 +35,8 @@ def stock_financial_hk_report_em(
         'client': 'PC',
         'v': '02092616586970355',
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result']['data'][0]['REPORT_LIST'])
     if indicator == "年度":
@@ -56,7 +58,8 @@ def stock_financial_hk_report_em(
             "client": "PC",
             "v": "01975982096513973",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         return temp_df
@@ -74,7 +77,8 @@ def stock_financial_hk_report_em(
             "client": "PC",
             "v": "01975982096513973",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         return temp_df
@@ -92,7 +96,8 @@ def stock_financial_hk_report_em(
             "client": "PC",
             "v": "01975982096513973",
         }
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         return temp_df
@@ -128,7 +133,8 @@ def stock_financial_hk_analysis_indicator_em(
         params.update({"filter": f"""(SECUCODE="{symbol}.HK")(DATE_TYPE_CODE="001")"""})
     else:
         params.update({"filter": f"""(SECUCODE="{symbol}.HK")"""})
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     return temp_df

--- a/akshare/stock_fundamental/stock_finance_ths.py
+++ b/akshare/stock_fundamental/stock_finance_ths.py
@@ -9,6 +9,7 @@ import json
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -31,7 +32,8 @@ def stock_financial_abstract_ths(
                       "AppleWebKit/537.36 (KHTML, like Gecko) "
                       "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     data_text = soup.find("p", attrs={"id": "main"}).string
     data_json = json.loads(data_text)
@@ -76,7 +78,8 @@ def stock_financial_debt_ths(
                       "AppleWebKit/537.36 (KHTML, like Gecko) "
                       "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = json.loads(json.loads(r.text)['flashData'])
     df_index = [
         item[0] if isinstance(item, list) else item for item in data_json["title"]
@@ -115,7 +118,8 @@ def stock_financial_benefit_ths(
                       "AppleWebKit/537.36 (KHTML, like Gecko) "
                       "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = json.loads(json.loads(r.text)['flashData'])
     df_index = [
         item[0] if isinstance(item, list) else item for item in data_json["title"]
@@ -158,7 +162,8 @@ def stock_financial_cash_ths(
                       "AppleWebKit/537.36 (KHTML, like Gecko) "
                       "Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     data_json = json.loads(json.loads(r.text)['flashData'])
     df_index = [
         item[0] if isinstance(item, list) else item for item in data_json["title"]

--- a/akshare/stock_fundamental/stock_hold.py
+++ b/akshare/stock_fundamental/stock_hold.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -29,7 +30,8 @@ def stock_institute_hold(symbol: str = "20051") -> pd.DataFrame:
         "reportdate": symbol[:-1],
         "quarter": symbol[-1],
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(StringIO(r.text))[0]
     temp_df["证券代码"] = temp_df["证券代码"].astype(str).str.zfill(6)
     del temp_df["明细"]
@@ -70,7 +72,8 @@ def stock_institute_hold_detail(
         "symbol": stock,
         "quarter": quarter,
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     text_data = r.text
     json_data = demjson.decode(text_data[text_data.find("{"): -2])
     big_df = pd.DataFrame()

--- a/akshare/stock_fundamental/stock_ipo_declare.py
+++ b/akshare/stock_fundamental/stock_ipo_declare.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/xg/xg/sbqy.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils import demjson
 
@@ -30,7 +31,8 @@ def stock_ipo_declare() -> pd.DataFrame:
         "mkt": "1",
         "fd": "2021-04-02",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_text = r.text
     data_json = demjson.decode(data_text[1:-1])
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]])

--- a/akshare/stock_fundamental/stock_kcb_detail_sse.py
+++ b/akshare/stock_fundamental/stock_kcb_detail_sse.py
@@ -5,6 +5,7 @@ Date: 2022/4/7 17:36
 Desc: http://kcb.sse.com.cn/renewal/xmxq/index.shtml?auditId=926&anchor_type=0
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 # TODO
@@ -24,7 +25,8 @@ def stock_kcb_detail_renewal():
         'Referer': 'http://kcb.sse.com.cn/',
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.60 Safari/537.36'
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json['result'])
     # 处理下 temp_df 里面的字段就可以了

--- a/akshare/stock_fundamental/stock_kcb_sse.py
+++ b/akshare/stock_fundamental/stock_kcb_sse.py
@@ -5,6 +5,7 @@ Date: 2022/4/7 17:36
 Desc: http://kcb.sse.com.cn/renewal/#
 """
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 import pandas as pd
 
 # TODO
@@ -47,7 +48,8 @@ def stock_kcb_renewal():
                 'pageHelp.endPage': page,
             }
         )
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result'])
         # 处理下 temp_df 里面的字段就可以了

--- a/akshare/stock_fundamental/stock_mda_ym.py
+++ b/akshare/stock_fundamental/stock_mda_ym.py
@@ -7,6 +7,7 @@ https://f10.emoney.cn/f10/zbyz/1000001
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -20,7 +21,8 @@ def stock_mda_ym(symbol: str = "000001") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"http://f10.emoney.cn/f10/zygc/{symbol}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     year_list = [
         item.text.strip()

--- a/akshare/stock_fundamental/stock_notice.py
+++ b/akshare/stock_fundamental/stock_notice.py
@@ -7,6 +7,7 @@ http://data.eastmoney.com/notices/hsa/5.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -43,7 +44,8 @@ def stock_notice_report(symbol: str = "全部", date: str = "20220511") -> pd.Da
         "begin_time": "-".join([date[:4], date[4:6], date[6:]]),
         "end_time": "-".join([date[:4], date[4:6], date[6:]]),
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     import math
 
@@ -56,7 +58,8 @@ def stock_notice_report(symbol: str = "全部", date: str = "20220511") -> pd.Da
                 "page_index": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["list"])
         temp_codes_df = pd.DataFrame(

--- a/akshare/stock_fundamental/stock_profit_forecast_em.py
+++ b/akshare/stock_fundamental/stock_profit_forecast_em.py
@@ -7,6 +7,7 @@ https://data.eastmoney.com/report/profitforecast.jshtml
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 from akshare.utils.tqdm import get_tqdm
 
@@ -35,7 +36,8 @@ def stock_profit_forecast_em(symbol: str = "") -> pd.DataFrame:
     if symbol:
         params.update({"filter": f'(INDUSTRY_BOARD="{symbol}")'})
 
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = int(data_json["result"]["pages"])
     big_df = pd.DataFrame()
@@ -49,7 +51,8 @@ def stock_profit_forecast_em(symbol: str = "") -> pd.DataFrame:
                 "pageNum": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)

--- a/akshare/stock_fundamental/stock_profit_forecast_hk_etnet.py
+++ b/akshare/stock_fundamental/stock_profit_forecast_hk_etnet.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_hk_profit_forecast_et(symbol: str = "09999", indicator: str = "盈利预测概览") -> pd.DataFrame:
@@ -26,7 +27,8 @@ def stock_hk_profit_forecast_et(symbol: str = "09999", indicator: str = "盈利�
     params = {
         "code": str(int(symbol)),
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     if indicator == "评级总览":
         temp_df = pd.read_html(StringIO(r.text))[0]
         inner_list = [item for item in temp_df.iloc[0, 0].split(" ") if item != ""]

--- a/akshare/stock_fundamental/stock_profit_forecast_ths.py
+++ b/akshare/stock_fundamental/stock_profit_forecast_ths.py
@@ -7,6 +7,7 @@ https://basic.10jqka.com.cn/new/600519/worth.html
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_profit_forecast_ths(
@@ -26,7 +27,8 @@ def stock_profit_forecast_ths(
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gbk"
     if indicator == "预测年报每股收益":
         temp_df = pd.read_html(r.text)[0]

--- a/akshare/stock_fundamental/stock_recommend.py
+++ b/akshare/stock_fundamental/stock_recommend.py
@@ -7,6 +7,7 @@ http://stock.finance.sina.com.cn/stock/go.php/vIR_RatingNewest/index.phtml
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -24,7 +25,8 @@ def stock_institute_recommend(symbol: str = "投资评级选股") -> pd.DataFram
         "num": "40",
         "p": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     indicator_map = {item.find("a").text: item.find("a")["href"] for item in soup.find(attrs={"id": "leftMenu"}).find_all("dd")[1].find_all("li")}
     url = indicator_map[symbol]
@@ -32,7 +34,8 @@ def stock_institute_recommend(symbol: str = "投资评级选股") -> pd.DataFram
         "num": "10000",
         "p": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     if symbol == "股票综合评级":
         temp_df = pd.read_html(r.text, header=0)[0].iloc[:, :9]
         temp_df["股票代码"] = temp_df["股票代码"].astype(str).str.zfill(6)
@@ -83,7 +86,8 @@ def stock_institute_recommend_detail(symbol: str = "000001") -> pd.DataFrame:
         "num": "5000",
         "p": "1",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     temp_df = pd.read_html(r.text, header=0)[0].iloc[:, :8]
     temp_df["股票代码"] = temp_df["股票代码"].astype(str).str.zfill(6)
     temp_df = temp_df.rename(columns={"评级日期↓": "评级日期"})

--- a/akshare/stock_fundamental/stock_register.py
+++ b/akshare/stock_fundamental/stock_register.py
@@ -7,6 +7,7 @@ http://data.eastmoney.com/kcb/?type=nsb
 """
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 
 
 def stock_register_kcb() -> pd.DataFrame:
@@ -31,7 +32,8 @@ def stock_register_kcb() -> pd.DataFrame:
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json['result']['pages']
     big_df = pd.DataFrame()
@@ -50,7 +52,8 @@ def stock_register_kcb() -> pd.DataFrame:
         headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']["data"])
         big_df = big_df.append(temp_df, ignore_index=True)
@@ -115,7 +118,8 @@ def stock_register_cyb() -> pd.DataFrame:
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json['result']['pages']
     big_df = pd.DataFrame()
@@ -134,7 +138,8 @@ def stock_register_cyb() -> pd.DataFrame:
         headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']["data"])
         big_df = big_df.append(temp_df, ignore_index=True)
@@ -200,7 +205,8 @@ def stock_register_db() -> pd.DataFrame:
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
     }
-    r = requests.get(url, params=params, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     page_num = data_json['result']['pages']
     big_df = pd.DataFrame()
@@ -209,7 +215,8 @@ def stock_register_db() -> pd.DataFrame:
         headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
         }
-        r = requests.get(url, params=params, headers=headers)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json['result']['data'])
         big_df = big_df.append(temp_df, ignore_index=True)

--- a/akshare/stock_fundamental/stock_restricted_em.py
+++ b/akshare/stock_fundamental/stock_restricted_em.py
@@ -8,6 +8,7 @@ https://data.eastmoney.com/dxf/detail.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from tqdm import tqdm
 
 
@@ -51,7 +52,8 @@ def stock_restricted_release_summary_em(
         '{start_date_str}')(FREE_DATE<='{end_date_str}')""",
         "reportName": "RPT_LIFTDAY_STA",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)
@@ -132,7 +134,8 @@ def stock_restricted_release_detail_em(
         "client": "WEB",
         "filter": f"""(FREE_DATE>='{start_date_str}')(FREE_DATE<='{end_date_str}')""",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     total_page = data_json["result"]["pages"]
     big_df = pd.DataFrame()
@@ -142,7 +145,8 @@ def stock_restricted_release_detail_em(
                 "pageNumber": page,
             }
         )
-        r = requests.get(url, params=params)
+        headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+        r = requests.get(url, params=params, headers=headers, timeout=timeout)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["result"]["data"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
@@ -229,7 +233,8 @@ def stock_restricted_release_queue_em(symbol: str = "600000") -> pd.DataFrame:
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     if not data_json["result"]:
         return pd.DataFrame()
@@ -325,7 +330,8 @@ def stock_restricted_release_stockholder_em(
         "source": "WEB",
         "client": "WEB",
     }
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["result"]["data"])
     temp_df.reset_index(inplace=True)

--- a/akshare/stock_fundamental/stock_zygc.py
+++ b/akshare/stock_fundamental/stock_zygc.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -23,7 +24,8 @@ def stock_zygc_ym(symbol: str = "000001") -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = f"http://f10.emoney.cn/f10/zygc/{symbol}"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     soup = BeautifulSoup(r.text, "lxml")
     year_list = [
         item.text.strip()
@@ -77,7 +79,8 @@ def stock_zygc_em(symbol: str = "SH688041") -> pd.DataFrame:
     """
     url = "https://emweb.securities.eastmoney.com/PC_HSF10/BusinessAnalysis/PageAjax"
     params = {"code": symbol}
-    r = requests.get(url, params=params)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
     data_json = r.json()
     temp_df = pd.DataFrame(data_json["zygcfx"])
     temp_df.rename(

--- a/akshare/stock_fundamental/stock_zyjs_ths.py
+++ b/akshare/stock_fundamental/stock_zyjs_ths.py
@@ -8,6 +8,7 @@ https://basic.10jqka.com.cn/new/000066/operate.html
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from bs4 import BeautifulSoup
 
 
@@ -25,7 +26,8 @@ def stock_zyjs_ths(symbol: str = "000066") -> pd.DataFrame:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/109.0.0.0 Safari/537.36"
     }
-    r = requests.get(url, headers=headers)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     r.encoding = "gb2312"
     soup = BeautifulSoup(r.text, "lxml")
     content_list = [

--- a/akshare/tool/trade_date_hist.py
+++ b/akshare/tool/trade_date_hist.py
@@ -11,6 +11,7 @@ import datetime
 
 import pandas as pd
 import requests
+from akshare.request_config_manager import get_headers_and_timeout
 from py_mini_racer import py_mini_racer
 
 from akshare.stock.cons import hk_js_decode
@@ -24,7 +25,8 @@ def tool_trade_date_hist_sina() -> pd.DataFrame:
     :rtype: pandas.DataFrame
     """
     url = "https://finance.sina.com.cn/realstock/company/klc_td_sh.txt"
-    r = requests.get(url)
+    headers, timeout = get_headers_and_timeout(locals().get('headers', {}), locals().get('timeout', None))
+    r = requests.get(url, headers=headers, timeout=timeout)
     js_code = py_mini_racer.MiniRacer()
     js_code.eval(hk_js_decode)
     dict_list = js_code.call("d", r.text.split("=")[1].split(";")[0].replace('"', ""))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,3 +25,4 @@ ruff>=0.3.3
 ruff-lsp>=0.0.53
 pre-commit>=3.6.2
 backtrader>=1.9.78.123  # just for test
+fake_useragent

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tabulate>=0.8.6
 decorator>=4.4.2
 py-mini-racer>=0.6.0
 akracer>=0.0.11
+fake_useragent


### PR DESCRIPTION
1.添加了基于环境变量的代理功能，用户可以设置自己的代理地址，实现ip切换等操作实现防止目标网站封IP。

2.对原函数进行了统一修改，为所有请求的请求头操作添加了基于fake-useragent库的随机user-agent效果，用于防止目标网站由于识别到python默认请求头而触发反爬。添加了可统一配置的timeout，用于防止在高频使用时因为网络连接问题出现的程序假死。对于原先不支持使用headers的请求操作，比如pd.read_csv(url)，修改为使用requests进行请求。修改量低，修改简单，影响小，后续添加新的接口也可以只使用一行代码完成修改。

3.为了便于用户灵活使用上述两个功能，添加了三个新函数：start_config, stop_config, change_proxy。

3.1change_proxy用于修改环境变量中的代理地址，输入str类型的地址。
     例：ak.change_proxy("http://my.proxy.com")

3.2start_config用于启动防反爬功能，提供基于时间和接口使用次数的自动停止，可以自己灵活选择是否使用代理、fake-user-agent和timeout，由于源代码中有些请求已经配置了headers和timeout，提供了force选项用于选择是否覆盖原先配置。
     例：ak.start_config(config_max_time=60, config_max_request=10, use_proxy=True, use_fake_user_agent=True, set_timeout=10, force=True),配置为启动配置，使用代理，使用fake-user-agent，timeout设置为10，覆盖可能的原有配置，60秒或10次ak.func()后自动关闭。
     输入参数默认为None或False，类型为bool和int，时间相关为float，可以不输入不想使用的配置功能，use_proxy，use_fake_user_agent，timeout必须输入至少一个否则报错。
     重复使用ak.start_config则重置start_config。

3.3stop_config，如字面意思，用于手动或强制停止防反爬功能，无输入，停止所有功能，节约资源。
     例：ak.stop_config()