### PR TITLE
Fix Type hint

### DIFF
--- a/akshare/option/option_commodity.py
+++ b/akshare/option/option_commodity.py
@@ -17,7 +17,7 @@ Desc: 商品期权数据
 import datetime
 import warnings
 from io import StringIO, BytesIO
-from typing import Tuple, Any
+from typing import Tuple, Any, Optional
 
 import pandas as pd
 import requests
@@ -34,7 +34,7 @@ from akshare.option.cons import (
 
 def option_dce_daily(
     symbol: str = "聚乙烯期权", trade_date: str = "20210728"
-) -> Tuple[Any, Any]:
+) -> Optional[Tuple[Any, Any]]:
     """
     大连商品交易所-期权-日频行情数据
     http://www.dce.com.cn/
@@ -225,7 +225,7 @@ def option_czce_daily(
 
 def option_shfe_daily(
     symbol: str = "铝期权", trade_date: str = "20200827"
-) -> pd.DataFrame:
+) -> Optional[pd.DataFrame]:
     """
     上海期货交易所-期权-日频行情数据
     https://tsite.shfe.com.cn/statements/dataview.html?paramid=kxQ


### PR DESCRIPTION
## Description
Fix Several type check warnings reported by Pyre@Google, which were outdated after code modifications.

## Detail
1. update the return type of function `option_dce_daily` from `Tuple[Any, Any]` to `Optional[Tuple[Any, Any]]`, since it could return None after commit https://github.com/akfamily/akshare/commit/543addaf96bfe3e4d6332808715bbe7eeccb7551
2. update the return type of function `option_shfe_daily` from `pd.DataFrame` to `Optional[pd.DataFrame]`, since it could return None after commit https://github.com/akfamily/akshare/commit/543addaf96bfe3e4d6332808715bbe7eeccb7551