### PR TITLE
stock_zh_kcb_report_em适配高版本pandas

### DIFF
--- a/akshare/stock/stock_zh_kcb_report.py
+++ b/akshare/stock/stock_zh_kcb_report.py
@@ -76,7 +76,7 @@ def stock_zh_kcb_report_em(from_page: int = 1, to_page: int = 100) -> pd.DataFra
                 [item["art_code"] for item in data_json["data"]["list"]],
             ]
         ).T
-        big_df = big_df.append(temp_df, ignore_index=True)
+        big_df = pd.concat([big_df, temp_df], ignore_index=True)
     big_df.columns = [
         "代码",
         "名称",


### PR DESCRIPTION
在pandas2.2.2当中使用stock_zh_kcb_report_em获取科创板公告会返回
Traceback (most recent call last):
  File "E:\Code\Finowth\FinData\original_test.py", line 3, in <module>
    stock_zh_kcb_report_em_df = ak.stock_zh_kcb_report_em(from_page=1, to_page=100)
  File "E:\Code\Finowth\FinData\.venv\lib\site-packages\akshare\stock\stock_zh_kcb_report.py", line 79, in stock_zh_kcb_report_em
    big_df = big_df.append(temp_df, ignore_index=True)
  File "E:\Code\Finowth\FinData\.venv\lib\site-packages\pandas\core\generic.py", line 6299, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'append'
因此修改该部分，已在低版本pandas实验无问题