### PR TITLE
对 Linux 使用 mini-racer (dev)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,7 @@ setuptools.setup(
         "jsonpath>=0.82",
         "tabulate>=0.8.6",
         "decorator>=4.4.2",
-        "mini-racer>=0.12.4;platform_system!='Linux'",
-        "py-mini-racer>=0.6.0;platform_system=='Linux'",
-        "akracer>=0.0.13;platform_system=='Linux'",
+        "mini-racer>=0.12.4",
     ],
     extras_require={
         # 这些是额外的依赖集合，可以通过 'pip install akshare[full]' 安装


### PR DESCRIPTION
### 问题

目前，akshare 在 Linux 平台上使用 py-mini-racer 和 akracer.
但是由于动态库文件名错误，在 Linux aarch64 平台上会导致 `import akshare` 报错
```
RuntimeError: Native library not available at /usr/lib/python3.12/site-packages/py_mini_racer/libmini_racer.glibc.so
```
实际文件名应为 `armlibmini_racer.glibc.so` 而非 `libmini_racer.glibc.so`.

### 解决方案

实际上，mini-racer 已经支持 Linux aarch64 平台，见 [compatibility](https://github.com/bpcreech/PyMiniRacer#compatibility)。
因此可以直接对所有平台直接使用 mini-racer.

### 测试

已在 Raspberry Pi 4B (OS: Arch Linux ARM) 上测试，可以完成导入。