### PR TITLE
fix: fix stock_dzjy_yybph

### DIFF
--- a/akshare/stock/stock_dzjy_em.py
+++ b/akshare/stock/stock_dzjy_em.py
@@ -493,7 +493,7 @@ def stock_dzjy_yybph(symbol: str = "近三月") -> pd.DataFrame:
     period_map = {
         "近一月": "30",
         "近三月": "90",
-        "近六月": "120",
+        "近六月": "180",
         "近一年": "360",
     }
     url = "https://datacenter-web.eastmoney.com/api/data/v1/get"


### PR DESCRIPTION
现象：stock_dzjy_yybph的symbol传入"近六月"时返回None导致报错；
修改：将period_map中的近六月由120修改为180；
文档：由于此修改不涉及接口变更，且原方法说明文档未对该字典作出说明，所以没有修改stock.md。