### PR TITLE
fix: lower aiohttp version requirement as aiohttp 3.11.13/3.11.14 are yanked

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 akqmt>=0.1.0
-aiohttp>=3.11.13
+aiohttp>=3.11.0
 beautifulsoup4>=4.9.1
 lxml>=4.2.1
 pandas>=0.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.11.13
+aiohttp>=3.11.0
 beautifulsoup4>=4.9.1
 lxml>=4.2.1
 pandas>=0.25

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     url="https://github.com/akfamily/akshare",
     packages=setuptools.find_packages(),
     install_requires=[
-        "aiohttp>=3.11.13",
+        "aiohttp>=3.11.0",
         "beautifulsoup4>=4.9.1",
         "lxml>=4.2.1",
         "pandas>=0.25",


### PR DESCRIPTION
由于 aiohttp 将 3.11.13 和 3.11.14 版本 [yank（撤包）](https://github.com/aio-libs/aiohttp/issues/10617)，当前使用 Poetry 添加此项目依赖时将无法安装，因此暂时降低版本要求来防止安装时报错