### PR TITLE
Fix: 去掉黄金交易所API冗余数据并按时间排序

### DIFF
--- a/akshare/spot/spot_sge.py
+++ b/akshare/spot/spot_sge.py
@@ -94,6 +94,14 @@ def spot_quotations_sge(symbol: str = "Au99.99") -> pd.DataFrame:
         }
     )
     temp_df["现价"] = pd.to_numeric(temp_df["现价"], errors="coerce")
+    # 将更新时间中的时间部分提取出来
+    update_time = temp_df["更新时间"].iloc[0].split()[1]
+    # 将时间列转换为时间格式以便排序
+    temp_df["时间"] = pd.to_datetime(temp_df["时间"], format="%H:%M").dt.time
+    # 过滤掉大于等于更新时间的数据
+    temp_df = temp_df[temp_df["时间"].astype(str) < update_time]
+    # 按时间排序
+    temp_df = temp_df.sort_values(by=["时间"])
     return temp_df
 
 


### PR DESCRIPTION
关于黄金交易所的API有些冗余数据，做了以下调整：
1. https://www.sge.com.cn/graph/quotations 的API会返回一个24小时的数据。根据观察得知，在今日没到的时间，返回昨日的数据。比如说，现在是9点整，那么在9点之前的数据都是今日数据，在9点之后的数据全是昨日9点之后的数据。这样的数据会有些混淆在里面，因此更改去掉昨日数据。
2. 黄金交易所的api是给他们一个chart使用，这个chart是从20点作为始点，所以API数据返回都是从20点开始。因此对数据，以时间排序展示，更符合一般使用和观察习惯。