### PR TITLE
fix: fix futures_global_hist_em

### DIFF
--- a/akshare/futures/futures_hf_em.py
+++ b/akshare/futures/futures_hf_em.py
@@ -237,6 +237,10 @@ def futures_global_hist_em(symbol: str = "HG00Y") -> pd.DataFrame:
     temp_df["总量"] = pd.to_numeric(temp_df["总量"], errors="coerce")
     temp_df["涨幅"] = pd.to_numeric(temp_df["涨幅"], errors="coerce")
     temp_df["日增"] = pd.to_numeric(temp_df["日增"], errors="coerce")
+    # 日增修复为有符号32位整数值
+    unsigned_max, signed_max = (2 ** 32) - 1, (2 ** 31) - 1
+    mask = temp_df["日增"] > signed_max
+    temp_df.loc[mask, "日增"] = temp_df.loc[mask, "日增"] - (unsigned_max + 1)
     return temp_df
 
 


### PR DESCRIPTION
修复东财国际期货行情中，日增字段负值解析的问题。例如2021-07-13的ES00Y原始日增数据为4294965937，实际它是有符号整数-1359。
其他日增字段无此问题。希望合并，谢谢。