### PR TITLE
feat: ak.futures_hist_em接口返回空时报错的问题

### DIFF
--- a/akshare/futures/futures_hist_em.py
+++ b/akshare/futures/futures_hist_em.py
@@ -136,6 +136,7 @@ def futures_hist_em(
     r = requests.get(url, timeout=15, params=params)
     data_json = r.json()
     temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])
+    if temp_df.empty: return temp_df
     temp_df.columns = [
         "时间",
         "开盘",


### PR DESCRIPTION
问题:
<img width="1160" height="474" alt="image" src="https://github.com/user-attachments/assets/444f6836-6901-4ae7-98cb-bc060e540205" />
在查询沪铜2608时,遇到该方法抛出如下异常

原因:
<img width="866" height="583" alt="image" src="https://github.com/user-attachments/assets/5eb447c9-7bbb-47f7-af17-fa7989d20801" />
对于空的DataFrame对象直接修改列会抛出如下异常.应该直接返回空的DataFrame
