### PR TITLE
fix: fix stock_notice_report

### DIFF
--- a/akshare/stock_fundamental/stock_notice.py
+++ b/akshare/stock_fundamental/stock_notice.py
@@ -61,9 +61,18 @@ def stock_notice_report(symbol: str = "全部", date: str = "20220511") -> pd.Da
         r = requests.get(url, params=params)
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"]["list"])
-        temp_codes_df = pd.DataFrame(
-            [item["codes"][0] for item in data_json["data"]["list"]]
-        )
+
+        temp_code_list = []
+        for item in data_json["data"]["list"]:
+            if len(item["codes"]) == 1:
+                temp_code_list.append(item["codes"][0])
+            else:
+                for code in item["codes"]:
+                    if code["ann_type"].startswith("A"):
+                        temp_code_list.append(code)
+                        break
+        temp_codes_df = pd.DataFrame(temp_code_list)
+
         try:
             temp_columns_df = pd.DataFrame(
                 [item["columns"][0] for item in data_json["data"]["list"]]


### PR DESCRIPTION
## 描述
修复 `stock_notice_report` 接口中股票代码关联错误的问题。接口返回的关联代码list可能不止一条，可能同时包含指数、a股、可转债等

## 问题重现
错误股票代码关联：
`stock_notice_report_df = stock_notice_report(symbol="风险提示", date="20200123")`
第二条 退市华业 及最后一条玉禾田都关联为000001