### PR TITLE
fix: fix _get_baidu_cookie

### DIFF
--- a/akshare/news/news_baidu.py
+++ b/akshare/news/news_baidu.py
@@ -9,7 +9,7 @@ import math
 import re
 
 import pandas as pd
-import requests
+from curl_cffi import requests
 
 
 def _get_baidu_cookie(headers: dict) -> str:
@@ -28,6 +28,7 @@ def _get_baidu_cookie(headers: dict) -> str:
             # 第一步：获取基础Cookie (BAIDUID系列)
             resp1 = session.get(
                 "https://gushitong.baidu.com/calendar",
+                impersonate="chrome110",
                 timeout=10
             )
             resp1.raise_for_status()
@@ -50,7 +51,7 @@ def _get_baidu_cookie(headers: dict) -> str:
             hm_url = "https:" + hm_match.group() if hm_match.group().startswith("//") else hm_match.group()
 
             # 第二步请求 (自动携带第一步的Cookie)
-            resp2 = session.get(hm_url, timeout=10)
+            resp2 = session.get(hm_url, impersonate="chrome110", timeout=10)
             resp2.raise_for_status()
 
             # 验证必要Cookie

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tabulate>=0.8.6
 decorator>=4.4.2
 mini-racer>=0.12.4
 nest_asyncio>=1.6.0
+curl_cffi>=0.13.0


### PR DESCRIPTION
添加curl_cffi库替代requests以解决百度对requests的TLS指纹封禁问题