### PR TITLE
在`stock_info_sh_name_code`的结果中暴露“证券全称”和“公司简称”这两列

### DIFF
--- a/akshare/stock/stock_info.py
+++ b/akshare/stock/stock_info.py
@@ -171,6 +171,8 @@ def stock_info_sh_name_code(symbol: str = "主板A股") -> pd.DataFrame:
         [
             "证券代码",
             "证券简称",
+            "证券全称",
+            "公司简称",
             "公司全称",
             "上市日期",
         ]


### PR DESCRIPTION
在PR #6876 中，关于`stock_info_sh_name_code`，从原始的JSON数据中已经找出了“证券全称”和“公司简称”，但是没有在最后结果中将其暴露出来，使得结果中还是只有“证券简称”和“公司全称”。

出于数据完整性的考虑，在此把“证券全称”和“公司简称”加到结果中，使结果中同时有“证券简称”、“证券全称”、“公司简称”、“公司全称”。
