### PR TITLE
feat: add stock_us_valuation_baidu

### DIFF
--- a/akshare/stock_feature/stock_us_valuation_baidu.py
+++ b/akshare/stock_feature/stock_us_valuation_baidu.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+"""
+Date: 2025/12/24 18:26
+Desc: 百度股市通-美股-财务报表-估值数据
+https://gushitong.baidu.com/stock/us-NVDA
+"""
+
+import http.client
+import json
+import urllib
+
+import pandas as pd
+
+
+def stock_us_valuation_baidu(
+    symbol: str = "NVDA", indicator: str = "总市值", period: str = "近一年"
+) -> pd.DataFrame:
+    """
+    百度股市通-美股-财务报表-估值数据
+    https://gushitong.baidu.com/stock/us-NVDA
+    :param symbol: 股票代码
+    :type symbol: str
+    :param indicator: choice of {"总市值", "市盈率(TTM)", "市盈率(静)", "市净率", "市现率"}
+    :type indicator: str
+    :param period: choice of {"近一年", "近三年", "全部"}
+    :type period: str
+    :return: 估值数据
+    :rtype: pandas.DataFrame
+    """
+    params = {
+        "openapi": "1",
+        "dspName": "iphone",
+        "tn": "tangram",
+        "client": "app",
+        "query": indicator,
+        "code": symbol,
+        "word": "",
+        "resource_id": "51171",
+        "market": "us",
+        "tag": indicator,
+        "chart_select": period,
+        "industry_select": "",
+        "skip_industry": "1",
+        "finClientType": "pc",
+    }
+    conn = http.client.HTTPSConnection("gushitong.baidu.com")
+    conn.request(method="GET", url=f"/opendata?{urllib.parse.urlencode(params)}")
+    r = conn.getresponse()
+    data_json = json.loads(r.read())
+    temp_df = pd.DataFrame(
+        data_json["Result"][0]["DisplayData"]["resultData"]["tplData"]["result"][
+            "chartInfo"
+        ][0]["body"]
+    )
+    temp_df.columns = ["date", "value"]
+    temp_df["date"] = pd.to_datetime(temp_df["date"]).dt.date
+    temp_df["value"] = pd.to_numeric(temp_df["value"])
+    return temp_df
+
+
+if __name__ == "__main__":
+    stock_us_valuation_baidu_df = stock_us_valuation_baidu(
+        symbol="NVDA", indicator="总市值", period="近一年"
+    )
+    print(stock_us_valuation_baidu_df)

--- a/docs/data/stock/stock.md
+++ b/docs/data/stock/stock.md
@@ -245,7 +245,7 @@ print(stock_szse_area_summary_df)
 33  34    青海  2.453409e+10  ...  6.640867e+09          0.0  2.349068e+06
 ```
 
-###### 
+######
 
 ###### 股票行业成交
 
@@ -17606,6 +17606,58 @@ print(stock_hk_valuation_baidu_df)
 365  2024-11-20  713.06
 366  2024-11-21  688.35
 [367 rows x 2 columns]
+```
+
+#### 美股估值指标
+
+接口: stock_us_valuation_baidu
+
+目标地址: https://gushitong.baidu.com/stock/us-NVDA
+
+描述: 百度股市通-美股-财务报表-估值数据
+
+限量: 单次获取指定 symbol 的指定 indicator 的特定 period 的历史数据
+
+输入参数
+
+| 名称        | 类型  | 描述                                                                     |
+|-----------|-----|------------------------------------------------------------------------|
+| symbol    | str | symbol="NVDA"; 美股代码                                                   |
+| indicator | str | indicator="总市值"; choice of {"总市值", "市盈率(TTM)", "市盈率(静)", "市净率", "市现率"} |
+| period    | str | period="近一年"; choice of {"近一年", "近三年", "全部"}                           |
+
+输出参数
+
+| 名称    | 类型      | 描述  |
+|-------|---------|-----|
+| date  | object  | -   |
+| value | float64 | -   |
+
+接口示例
+
+```python
+import akshare as ak
+
+stock_us_valuation_baidu_df = ak.stock_us_valuation_baidu(symbol="NVDA", indicator="总市值", period="近一年")
+print(stock_us_valuation_baidu_df)
+```
+
+数据示例
+
+```
+           date     value
+0    2024-12-24  34339.88
+1    2024-12-26  34268.86
+2    2024-12-27  33553.75
+3    2024-12-30  33671.30
+4    2024-12-31  32887.62
+..          ...       ...
+245  2025-12-17  41538.42
+246  2025-12-18  42316.02
+247  2025-12-19  43980.57
+248  2025-12-22  44636.67
+249  2025-12-23  45978.03
+[250 rows x 2 columns]
 ```
 
 #### 创新高和新低的股票数量


### PR DESCRIPTION
### 修复/新增功能说明
新增百度美股估值数据接口 `stock_us_valuation_baidu`。

### 变更清单
1. 新增文件 `akshare/stock_feature/stock_us_valuation_baidu.py` 用于抓取数据。
2. 更新文档 `docs/data/stock/stock.md`，添加了接口说明。

### 测试用例
import akshare as ak
stock_us_valuation_baidu_df = ak.stock_us_valuation_baidu(symbol="NVDA", indicator="总市值", period="近一年")
print(stock_us_valuation_baidu_df)