### PR TITLE
为 fetch_paginated_data 添加重试机制、随机抖动和指数退避

### DIFF
--- a/akshare/utils/func.py
+++ b/akshare/utils/func.py
@@ -5,11 +5,13 @@ Desc: 通用帮助函数
 """
 
 import math
+import random
+import time
 from typing import List, Dict
 
 import pandas as pd
-import requests
 
+from akshare.utils.request import request_with_retry
 from akshare.utils.tqdm import get_tqdm
 
 
@@ -29,7 +31,7 @@ def fetch_paginated_data(url: str, base_params: Dict, timeout: int = 15):
     # 复制参数以避免修改原始参数
     params = base_params.copy()
     # 获取第一页数据，用于确定分页信息
-    r = requests.get(url, params=params, timeout=timeout)
+    r = request_with_retry(url, params=params, timeout=timeout)
     data_json = r.json()
     # 计算分页信息
     per_page_num = len(data_json["data"]["diff"])
@@ -43,7 +45,9 @@ def fetch_paginated_data(url: str, base_params: Dict, timeout: int = 15):
     # 获取剩余页面数据
     for page in tqdm(range(2, total_page + 1), leave=False):
         params.update({"pn": page})
-        r = requests.get(url, params=params, timeout=timeout)
+        # 添加随机延迟，避免请求过于频繁
+        time.sleep(random.uniform(0.5, 1.5))
+        r = request_with_retry(url, params=params, timeout=timeout)
         data_json = r.json()
         inner_temp_df = pd.DataFrame(data_json["data"]["diff"])
         temp_list.append(inner_temp_df)

--- a/akshare/utils/request.py
+++ b/akshare/utils/request.py
@@ -1,0 +1,64 @@
+# !/usr/bin/env python
+"""
+Date: 2025/12/31
+Desc: HTTP 请求工具函数
+"""
+
+import random
+import time
+from typing import Dict, Tuple
+
+import requests
+from requests.adapters import HTTPAdapter
+
+
+def request_with_retry(
+    url: str,
+    params: Dict = None,
+    timeout: int = 15,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    random_delay_range: Tuple[float, float] = (0.5, 1.5),
+) -> requests.Response:
+    """
+    带重试机制的 HTTP GET 请求
+    :param url: 请求 URL
+    :type url: str
+    :param params: 请求参数
+    :type params: dict
+    :param timeout: 超时时间（秒）
+    :type timeout: int
+    :param max_retries: 最大重试次数
+    :type max_retries: int
+    :param base_delay: 基础延迟时间（秒），用于指数退避
+    :type base_delay: float
+    :param random_delay_range: 随机延迟范围（秒）
+    :type random_delay_range: tuple
+    :return: Response 对象
+    :rtype: requests.Response
+    :raises: 最后一次请求的异常
+    """
+    last_exception = None
+
+    for attempt in range(max_retries):
+        try:
+            # 每次请求创建新的 Session，避免复用连接
+            with requests.Session() as session:
+                # 禁用连接池复用
+                adapter = HTTPAdapter(pool_connections=1, pool_maxsize=1)
+                session.mount("http://", adapter)
+                session.mount("https://", adapter)
+
+                response = session.get(url, params=params, timeout=timeout)
+                response.raise_for_status()
+                return response
+
+        except (requests.RequestException, ValueError) as e:
+            last_exception = e
+
+            if attempt < max_retries - 1:
+                # 指数退避 + 随机抖动
+                delay = base_delay * (2 ** attempt) + random.uniform(*random_delay_range)
+                time.sleep(delay)
+
+    raise last_exception


### PR DESCRIPTION
### 问题背景

`fetch_paginated_data` 函数用于从东方财富分页获取股票数据，原实现存在以下问题：

1. **无请求间隔**：循环请求之间没有任何延迟，容易触发反爬虫机制
2. **无重试机制**：一旦某个请求失败（如网络抖动、SSL 错误），整个函数立即失败
3. **无断点恢复**：失败后用户只能从头开始重新下载，即使已下载的数据也需重新获取

实际运行中遇到的典型错误：

```bash
  0%|                                                                                                        | 0/57 [00:00<?, ?it/s]5.79it/s]
...
 65%|#############################################################6                                 | 37/57 [00:07<00:02,  6.87it/s]
HTTPSConnectionPool(host='82.push2.eastmoney.com', port=443): Max retries exceeded with url: 
/api/qt/clist/get?pn=39&... (Caused by SSLError(SSLEOFError(8, 
'[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1010)')))
```

### 解决方案

新增 `akshare/utils/request.py` 模块，实现 `request_with_retry` 函数：

1. **指数退避重试**：默认最多重试 3 次，延迟时间按 1s → 2s → 4s 递增
2. **随机抖动**：在基础延迟上添加 0.5-1.5 秒随机时间，降低请求规律性
3. **禁用连接复用**：每次请求创建新 Session，避免连接池状态污染
4. **请求间隔**：分页循环中每次请求前添加 0.5-1.5 秒随机延迟

### 变更文件

**新增**
- `akshare/utils/request.py`：可复用的 HTTP 请求工具模块

**修改**
- `akshare/utils/func.py`：使用新的请求工具替换原 `requests.get` 调用

### 兼容性

- 函数签名和返回值保持不变，对外部调用者透明
- 新增的延迟会轻微增加总耗时，但显著提高成功率
