### PR TITLE
fix(stock): support ETF symbols in stock_zh_a_daily (e.g. sh512400)

### DIFF
--- a/akshare/stock/stock_zh_a_sina.py
+++ b/akshare/stock/stock_zh_a_sina.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 """
-Date: 2026/1/9 22:00
+Date: 2026/3/4 20:00
 Desc: 新浪财经-A股-实时行情数据和历史行情数据(包含前复权和后复权因子)
 https://finance.sina.com.cn/realstock/company/sh689009/nc.shtml
 """
@@ -153,6 +153,7 @@ def stock_zh_a_daily(
             )
             if hfq_factor_df.shape[0] == 0:
                 raise ValueError("sina hfq factor not available")
+            hfq_factor_df = hfq_factor_df[["d", "f"]]
             hfq_factor_df.columns = ["date", "hfq_factor"]
             hfq_factor_df.index = pd.to_datetime(hfq_factor_df.date)
             del hfq_factor_df["date"]
@@ -165,6 +166,7 @@ def stock_zh_a_daily(
             )
             if qfq_factor_df.shape[0] == 0:
                 raise ValueError("sina hfq factor not available")
+            qfq_factor_df = qfq_factor_df[["d", "f"]]
             qfq_factor_df.columns = ["date", "qfq_factor"]
             qfq_factor_df.index = pd.to_datetime(qfq_factor_df.date)
             del qfq_factor_df["date"]
@@ -194,11 +196,22 @@ def stock_zh_a_daily(
         pass
     data_df = data_df.astype("float")
     r = requests.get(zh_sina_a_stock_amount_url.format(symbol, symbol))
-    amount_data_json = demjson.decode(r.text[r.text.find("[") : r.text.rfind("]") + 1])
-    amount_data_df = pd.DataFrame(amount_data_json)
-    amount_data_df.columns = ["date", "outstanding_share"]
-    amount_data_df.index = pd.to_datetime(amount_data_df.date)
-    del amount_data_df["date"]
+    amount_text = r.text[r.text.find("[") : r.text.rfind("]") + 1]
+
+    if "null" in amount_text.lower() or not amount_text.strip():
+        # Fallback for ETFs or indices where share amounts are empty/null
+        amount_data_df = pd.DataFrame(
+            {"date": data_df.index.unique(), "outstanding_share": 0.0}
+        )
+        amount_data_df.index = pd.to_datetime(amount_data_df.date)
+        del amount_data_df["date"]
+    else:
+        amount_data_json = demjson.decode(amount_text)
+        amount_data_df = pd.DataFrame(amount_data_json)
+        amount_data_df.columns = ["date", "outstanding_share"]
+        amount_data_df.index = pd.to_datetime(amount_data_df.date)
+        del amount_data_df["date"]
+
     temp_df = pd.merge(
         data_df, amount_data_df, left_index=True, right_index=True, how="outer"
     )
@@ -213,7 +226,13 @@ def stock_zh_a_daily(
 
     temp_df = temp_df.astype(float)
     temp_df["outstanding_share"] = temp_df["outstanding_share"] * 10000
-    temp_df["turnover"] = temp_df["volume"] / temp_df["outstanding_share"]
+
+    # Handle division by zero for turnover if outstanding_share is 0 (like for ETFs)
+    if (temp_df["outstanding_share"] == 0).all():
+        temp_df["turnover"] = 0.0
+    else:
+        temp_df["turnover"] = temp_df["volume"] / temp_df["outstanding_share"]
+
     temp_df.columns = [
         "open",
         "high",
@@ -243,6 +262,8 @@ def stock_zh_a_daily(
         hfq_factor_df = pd.DataFrame(
             eval(res.text.split("=")[1].split("\n")[0])["data"]
         )
+        # 兼容 ETF 多出的 s和u列
+        hfq_factor_df = hfq_factor_df[["d", "f"]]
         hfq_factor_df.columns = ["date", "hfq_factor"]
         hfq_factor_df.index = pd.to_datetime(hfq_factor_df.date)
         del hfq_factor_df["date"]
@@ -287,6 +308,8 @@ def stock_zh_a_daily(
         qfq_factor_df = pd.DataFrame(
             eval(res.text.split("=")[1].split("\n")[0])["data"]
         )
+        # 兼容 ETF 多出的 s和u列
+        qfq_factor_df = qfq_factor_df[["d", "f"]]
         qfq_factor_df.columns = ["date", "qfq_factor"]
         qfq_factor_df.index = pd.to_datetime(qfq_factor_df.date)
         del qfq_factor_df["date"]

--- a/tests/test_stock_zh_a_sina_etf.py
+++ b/tests/test_stock_zh_a_sina_etf.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+"""
+Date: 2026/3/4 20:00
+Desc: Tests for ETF support in stock_zh_a_daily (stock_zh_a_sina.py)
+
+Fixes verified:
+1. ETF with null outstanding_share no longer crashes (fallback to 0.0)
+2. Division-by-zero in turnover calculation is handled for ETFs
+3. Extra columns (s, u) in ETF qfq/hfq factor data no longer cause column mismatch
+
+Note: These tests make real network requests to the Sina Finance API.
+      Run in a networked environment.
+"""
+
+import pandas as pd
+import pytest
+
+from akshare.stock.stock_zh_a_sina import stock_zh_a_daily
+
+# ETF symbol that previously triggered all three bugs
+ETF_SYMBOL = "sh512400"
+# A normal A-share stock for regression testing
+NORMAL_SYMBOL = "sh600000"
+
+
+class TestETFNoAdjust:
+    """ETF data without adjustment — verifies null outstanding_share fix."""
+
+    def test_returns_dataframe(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="")
+        assert isinstance(df, pd.DataFrame), "Should return a DataFrame"
+        assert not df.empty, "DataFrame should not be empty"
+
+    def test_has_required_columns(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="")
+        required = {
+            "date",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "amount",
+            "outstanding_share",
+            "turnover",
+        }
+        assert required.issubset(df.columns), (
+            f"Missing columns: {required - set(df.columns)}"
+        )
+
+    def test_turnover_is_zero_for_etf(self):
+        """ETFs have no outstanding_share, so turnover must be 0.0 (not NaN or inf)."""
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="")
+        assert (df["turnover"] == 0.0).all(), (
+            "ETF turnover should be 0.0 when outstanding_share is unavailable"
+        )
+
+    def test_no_inf_or_nan_in_numeric_columns(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="")
+        numeric_cols = df.select_dtypes(include="number").columns
+        assert not df[numeric_cols].isin([float("inf"), float("-inf")]).any().any(), (
+            "No infinite values allowed"
+        )
+        # outstanding_share and turnover may be 0 but not NaN
+        assert df["turnover"].notna().all(), "turnover should not contain NaN"
+
+
+class TestETFHfq:
+    """ETF with back-adjustment (hfq) — verifies extra-column fix for hfq factor data."""
+
+    def test_does_not_crash(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="hfq")
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_has_close_column(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="hfq")
+        assert "close" in df.columns
+
+    def test_close_is_numeric(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="hfq")
+        assert pd.api.types.is_float_dtype(df["close"]), "close should be float"
+
+
+class TestETFQfq:
+    """ETF with forward-adjustment (qfq) — verifies extra-column fix for qfq factor data."""
+
+    def test_does_not_crash(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="qfq")
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_has_close_column(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="qfq")
+        assert "close" in df.columns
+
+    def test_close_is_numeric(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="qfq")
+        assert pd.api.types.is_float_dtype(df["close"]), "close should be float"
+
+
+class TestETFFactorOnly:
+    """ETF factor-only modes — verifies column fix inside _fq_factor()."""
+
+    def test_hfq_factor_returns_dataframe(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="hfq-factor")
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_hfq_factor_has_correct_columns(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="hfq-factor")
+        assert "hfq_factor" in df.columns
+        assert "date" in df.columns
+
+    def test_qfq_factor_returns_dataframe(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="qfq-factor")
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_qfq_factor_has_correct_columns(self):
+        df = stock_zh_a_daily(symbol=ETF_SYMBOL, adjust="qfq-factor")
+        assert "qfq_factor" in df.columns
+        assert "date" in df.columns
+
+
+class TestNormalStockRegression:
+    """Regression: normal A-share stocks should still work correctly."""
+
+    def test_no_adjust_returns_data(self):
+        df = stock_zh_a_daily(symbol=NORMAL_SYMBOL, adjust="")
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_qfq_returns_data(self):
+        df = stock_zh_a_daily(symbol=NORMAL_SYMBOL, adjust="qfq")
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_hfq_returns_data(self):
+        df = stock_zh_a_daily(symbol=NORMAL_SYMBOL, adjust="hfq")
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_normal_stock_has_nonzero_turnover(self):
+        """Normal stocks should have non-zero turnover rates."""
+        df = stock_zh_a_daily(symbol=NORMAL_SYMBOL, adjust="")
+        # At least some rows should have positive turnover
+        assert (df["turnover"] > 0).any(), (
+            "Normal stock should have positive turnover for at least some days"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
fix(stock): support ETF symbols in stock_zh_a_daily (e.g. sh512400)
- Handle null/empty outstanding_share response from Sina API for ETFs;
  fall back to 0.0 instead of crashing during JSON parse
- Guard against ZeroDivisionError when computing turnover for ETFs
  (outstanding_share == 0)
- Slice [["d", "f"]] before renaming qfq/hfq factor columns to handle
  extra "s" and "u" columns present in ETF factor data
All five adjust modes ("", "hfq", "qfq", "hfq-factor", "qfq-factor")
verified against live Sina API with sh512400. No regression for normal
A-share stocks (sh600000).
Tests: tests/test_stock_zh_a_sina_etf.py — 18 passed