### PR TITLE
Add optional Adanos US stock sentiment data

### DIFF
--- a/akshare/__init__.py
+++ b/akshare/__init__.py
@@ -5616,6 +5616,10 @@ from akshare.stock.stock_us_sina import (
     stock_us_spot,
     get_us_stock_name,
 )
+from akshare.stock.stock_us_adanos import (
+    stock_us_adanos_sentiment,
+    stock_us_adanos_compare,
+)
 
 """
 新浪-港股实时行情数据和历史数据(前复权和后复权因子)

--- a/akshare/stock/stock_us_adanos.py
+++ b/akshare/stock/stock_us_adanos.py
@@ -16,6 +16,36 @@ ADANOS_SOURCES = {"reddit", "x", "news", "polymarket"}
 ADANOS_REQUEST_TIMEOUT = 30
 
 
+def _normalize_symbol(symbol: str) -> str:
+    """
+    规范化单个美股代码
+    :param symbol: 美股代码
+    :type symbol: str
+    :return: 规范化后的美股代码
+    :rtype: str
+    """
+    symbol = symbol.strip().upper()
+    if not symbol:
+        raise ValueError("symbol must not be empty.")
+    return symbol
+
+
+def _normalize_symbols(symbols: str) -> str:
+    """
+    规范化多个美股代码
+    :param symbols: 英文逗号分隔的美股代码
+    :type symbols: str
+    :return: 规范化后的美股代码
+    :rtype: str
+    """
+    normalized_symbols = ",".join(
+        symbol.strip().upper() for symbol in symbols.split(",") if symbol.strip()
+    )
+    if not normalized_symbols:
+        raise ValueError("symbols must contain at least one symbol.")
+    return normalized_symbols
+
+
 def _get_adanos_api_key(api_key: str = "") -> str:
     """
     获取 Adanos API Key
@@ -24,7 +54,7 @@ def _get_adanos_api_key(api_key: str = "") -> str:
     :return: Adanos API Key
     :rtype: str
     """
-    adanos_api_key = api_key or os.getenv("ADANOS_API_KEY", "")
+    adanos_api_key = (api_key or os.getenv("ADANOS_API_KEY", "")).strip()
     if not adanos_api_key:
         raise ValueError("Please provide api_key or set ADANOS_API_KEY.")
     return adanos_api_key
@@ -38,7 +68,7 @@ def _validate_source(source: str) -> str:
     :return: 数据源
     :rtype: str
     """
-    source = source.lower()
+    source = source.strip().lower()
     if source not in ADANOS_SOURCES:
         raise ValueError("source must be one of: reddit, x, news, polymarket")
     return source
@@ -134,7 +164,7 @@ def stock_us_adanos_sentiment(
     """
     source = _validate_source(source)
     data_json = _request_adanos(
-        path=f"/{source}/stocks/v1/stock/{symbol.upper()}",
+        path=f"/{source}/stocks/v1/stock/{_normalize_symbol(symbol)}",
         params={"days": days},
         api_key=_get_adanos_api_key(api_key),
         base_url=base_url,
@@ -173,7 +203,7 @@ def stock_us_adanos_compare(
     source = _validate_source(source)
     data_json = _request_adanos(
         path=f"/{source}/stocks/v1/compare",
-        params={"tickers": symbols.upper(), "days": days},
+        params={"tickers": _normalize_symbols(symbols), "days": days},
         api_key=_get_adanos_api_key(api_key),
         base_url=base_url,
         timeout=timeout,
@@ -185,12 +215,13 @@ def stock_us_adanos_compare(
 
 
 if __name__ == "__main__":
+    adanos_api_key = os.getenv("ADANOS_API_KEY", "")
     stock_us_adanos_sentiment_df = stock_us_adanos_sentiment(
-        symbol="TSLA", source="reddit", api_key=""
+        symbol="TSLA", source="reddit", api_key=adanos_api_key
     )
     print(stock_us_adanos_sentiment_df)
 
     stock_us_adanos_compare_df = stock_us_adanos_compare(
-        symbols="TSLA,NVDA,AAPL", source="reddit", api_key=""
+        symbols="TSLA,NVDA,AAPL", source="reddit", api_key=adanos_api_key
     )
     print(stock_us_adanos_compare_df)

--- a/akshare/stock/stock_us_adanos.py
+++ b/akshare/stock/stock_us_adanos.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+"""
+Date: 2026/05/03
+Desc: Adanos Market Sentiment API-美股市场情绪数据
+https://api.adanos.org
+"""
+
+import os
+
+import pandas as pd
+import requests
+
+ADANOS_BASE_URL = "https://api.adanos.org"
+ADANOS_SOURCES = {"reddit", "x", "news", "polymarket"}
+ADANOS_REQUEST_TIMEOUT = 30
+
+
+def _get_adanos_api_key(api_key: str = "") -> str:
+    """
+    获取 Adanos API Key
+    :param api_key: Adanos API Key
+    :type api_key: str
+    :return: Adanos API Key
+    :rtype: str
+    """
+    adanos_api_key = api_key or os.getenv("ADANOS_API_KEY", "")
+    if not adanos_api_key:
+        raise ValueError("Please provide api_key or set ADANOS_API_KEY.")
+    return adanos_api_key
+
+
+def _validate_source(source: str) -> str:
+    """
+    校验 Adanos 数据源
+    :param source: 数据源
+    :type source: str
+    :return: 数据源
+    :rtype: str
+    """
+    source = source.lower()
+    if source not in ADANOS_SOURCES:
+        raise ValueError("source must be one of: reddit, x, news, polymarket")
+    return source
+
+
+def _request_adanos(
+    path: str,
+    params: dict,
+    api_key: str,
+    base_url: str,
+    timeout: int,
+) -> dict:
+    """
+    请求 Adanos API
+    :param path: API 路径
+    :type path: str
+    :param params: 请求参数
+    :type params: dict
+    :param api_key: Adanos API Key
+    :type api_key: str
+    :param base_url: API 地址
+    :type base_url: str
+    :param timeout: 超时时间
+    :type timeout: int
+    :return: JSON 数据
+    :rtype: dict
+    """
+    url = f"{base_url.rstrip('/')}{path}"
+    headers = {"X-API-Key": api_key, "Accept": "application/json"}
+    r = requests.get(url, params=params, headers=headers, timeout=timeout)
+    r.raise_for_status()
+    return r.json()
+
+
+def _flatten_stock(item: dict, source: str) -> dict:
+    """
+    展平单个股票情绪数据
+    :param item: API 返回数据
+    :type item: dict
+    :param source: 数据源
+    :type source: str
+    :return: 展平后的数据
+    :rtype: dict
+    """
+    return {
+        "source": source,
+        "ticker": item.get("ticker"),
+        "company_name": item.get("company_name"),
+        "buzz_score": item.get("buzz_score"),
+        "trend": item.get("trend"),
+        "sentiment_score": item.get("sentiment_score"),
+        "mentions": item.get("mentions"),
+        "unique_tweets": item.get("unique_tweets"),
+        "trade_count": item.get("trade_count"),
+        "market_count": item.get("market_count"),
+        "unique_traders": item.get("unique_traders"),
+        "total_liquidity": item.get("total_liquidity"),
+        "positive_count": item.get("positive_count"),
+        "negative_count": item.get("negative_count"),
+        "neutral_count": item.get("neutral_count"),
+        "bullish_pct": item.get("bullish_pct"),
+        "bearish_pct": item.get("bearish_pct"),
+        "period_days": item.get("period_days"),
+        "trend_history": item.get("trend_history"),
+    }
+
+
+def stock_us_adanos_sentiment(
+    symbol: str = "TSLA",
+    source: str = "reddit",
+    days: int = 7,
+    api_key: str = "",
+    base_url: str = ADANOS_BASE_URL,
+    timeout: int = ADANOS_REQUEST_TIMEOUT,
+) -> pd.DataFrame:
+    """
+    Adanos Market Sentiment API-美股个股市场情绪数据
+    https://api.adanos.org
+    :param symbol: 美股代码, 如: "TSLA"; 不需要添加交易所前缀
+    :type symbol: str
+    :param source: 数据源, 可选值: "reddit", "x", "news", "polymarket"
+    :type source: str
+    :param days: 最近 N 天数据
+    :type days: int
+    :param api_key: Adanos API Key; 也可以设置环境变量 ADANOS_API_KEY
+    :type api_key: str
+    :param base_url: Adanos API 地址
+    :type base_url: str
+    :param timeout: 请求超时时间
+    :type timeout: int
+    :return: 美股个股市场情绪数据
+    :rtype: pandas.DataFrame
+    """
+    source = _validate_source(source)
+    data_json = _request_adanos(
+        path=f"/{source}/stocks/v1/stock/{symbol.upper()}",
+        params={"days": days},
+        api_key=_get_adanos_api_key(api_key),
+        base_url=base_url,
+        timeout=timeout,
+    )
+    temp_df = pd.DataFrame([_flatten_stock(data_json, source)])
+    return temp_df
+
+
+def stock_us_adanos_compare(
+    symbols: str = "TSLA,NVDA,AAPL",
+    source: str = "reddit",
+    days: int = 7,
+    api_key: str = "",
+    base_url: str = ADANOS_BASE_URL,
+    timeout: int = ADANOS_REQUEST_TIMEOUT,
+) -> pd.DataFrame:
+    """
+    Adanos Market Sentiment API-美股多股票市场情绪对比
+    https://api.adanos.org
+    :param symbols: 英文逗号分隔的美股代码, 如: "TSLA,NVDA,AAPL"
+    :type symbols: str
+    :param source: 数据源, 可选值: "reddit", "x", "news", "polymarket"
+    :type source: str
+    :param days: 最近 N 天数据
+    :type days: int
+    :param api_key: Adanos API Key; 也可以设置环境变量 ADANOS_API_KEY
+    :type api_key: str
+    :param base_url: Adanos API 地址
+    :type base_url: str
+    :param timeout: 请求超时时间
+    :type timeout: int
+    :return: 美股多股票市场情绪对比
+    :rtype: pandas.DataFrame
+    """
+    source = _validate_source(source)
+    data_json = _request_adanos(
+        path=f"/{source}/stocks/v1/compare",
+        params={"tickers": symbols.upper(), "days": days},
+        api_key=_get_adanos_api_key(api_key),
+        base_url=base_url,
+        timeout=timeout,
+    )
+    temp_df = pd.DataFrame(
+        [_flatten_stock(item, source) for item in data_json.get("stocks", [])]
+    )
+    return temp_df
+
+
+if __name__ == "__main__":
+    stock_us_adanos_sentiment_df = stock_us_adanos_sentiment(
+        symbol="TSLA", source="reddit", api_key=""
+    )
+    print(stock_us_adanos_sentiment_df)
+
+    stock_us_adanos_compare_df = stock_us_adanos_compare(
+        symbols="TSLA,NVDA,AAPL", source="reddit", api_key=""
+    )
+    print(stock_us_adanos_compare_df)

--- a/docs/data/stock/stock.md
+++ b/docs/data/stock/stock.md
@@ -3711,6 +3711,91 @@ print(stock_zh_ah_name_df)
 
 ### 美股
 
+#### 市场情绪数据-Adanos
+
+接口: stock_us_adanos_sentiment
+
+目标地址: https://api.adanos.org
+
+描述: Adanos Market Sentiment API-美股个股市场情绪数据; 支持 Reddit、X、News、Polymarket 数据源; 需要传入 Adanos API Key 或设置环境变量 `ADANOS_API_KEY`
+
+限量: 单次返回指定美股代码最近 N 天的市场情绪数据
+
+输入参数
+
+| 名称     | 类型  | 描述                                                            |
+|--------|-----|---------------------------------------------------------------|
+| symbol | str | symbol="TSLA"; 美股代码, 不需要添加交易所前缀                              |
+| source | str | source="reddit"; choice of {"reddit", "x", "news", "polymarket"} |
+| days   | int | days=7; 最近 N 天数据                                              |
+| api_key | str | api_key=""; Adanos API Key, 也可以设置环境变量 `ADANOS_API_KEY`          |
+
+输出参数
+
+| 名称              | 类型      | 描述          |
+|-----------------|---------|-------------|
+| source          | object  | 数据源         |
+| ticker          | object  | 美股代码        |
+| company_name    | object  | 公司名称        |
+| buzz_score      | float64 | 热度评分        |
+| trend           | object  | 趋势          |
+| sentiment_score | float64 | 情绪评分        |
+| mentions        | int64   | 提及数量        |
+| unique_tweets   | int64   | X 数据源推文数量   |
+| trade_count     | int64   | Polymarket 交易数量 |
+| market_count    | int64   | Polymarket 市场数量 |
+| total_liquidity | float64 | Polymarket 流动性  |
+| trend_history   | object  | 最近 N 天趋势序列  |
+
+接口示例
+
+```python
+import akshare as ak
+
+stock_us_adanos_sentiment_df = ak.stock_us_adanos_sentiment(
+    symbol="TSLA",
+    source="reddit",
+    days=7,
+    api_key="此处输入 API",
+)
+print(stock_us_adanos_sentiment_df)
+```
+
+接口: stock_us_adanos_compare
+
+目标地址: https://api.adanos.org
+
+描述: Adanos Market Sentiment API-美股多股票市场情绪对比
+
+限量: 单次返回多个美股代码最近 N 天的市场情绪对比数据
+
+输入参数
+
+| 名称      | 类型  | 描述                                                            |
+|---------|-----|---------------------------------------------------------------|
+| symbols | str | symbols="TSLA,NVDA,AAPL"; 英文逗号分隔的美股代码                       |
+| source  | str | source="reddit"; choice of {"reddit", "x", "news", "polymarket"} |
+| days    | int | days=7; 最近 N 天数据                                              |
+| api_key | str | api_key=""; Adanos API Key, 也可以设置环境变量 `ADANOS_API_KEY`          |
+
+输出参数
+
+同 `stock_us_adanos_sentiment`。
+
+接口示例
+
+```python
+import akshare as ak
+
+stock_us_adanos_compare_df = ak.stock_us_adanos_compare(
+    symbols="TSLA,NVDA,AAPL",
+    source="news",
+    days=7,
+    api_key="此处输入 API",
+)
+print(stock_us_adanos_compare_df)
+```
+
 #### 实时行情数据-东财
 
 接口: stock_us_spot_em

--- a/docs/data/stock/stock.md
+++ b/docs/data/stock/stock.md
@@ -3744,7 +3744,14 @@ print(stock_zh_ah_name_df)
 | unique_tweets   | int64   | X 数据源推文数量   |
 | trade_count     | int64   | Polymarket 交易数量 |
 | market_count    | int64   | Polymarket 市场数量 |
+| unique_traders  | int64   | Polymarket 交易者数量 |
 | total_liquidity | float64 | Polymarket 流动性  |
+| positive_count  | int64   | 正面提及数量      |
+| negative_count  | int64   | 负面提及数量      |
+| neutral_count   | int64   | 中性提及数量      |
+| bullish_pct     | float64 | 看涨比例        |
+| bearish_pct     | float64 | 看跌比例        |
+| period_days     | int64   | 统计周期天数      |
 | trend_history   | object  | 最近 N 天趋势序列  |
 
 接口示例
@@ -3773,7 +3780,7 @@ print(stock_us_adanos_sentiment_df)
 
 | 名称      | 类型  | 描述                                                            |
 |---------|-----|---------------------------------------------------------------|
-| symbols | str | symbols="TSLA,NVDA,AAPL"; 英文逗号分隔的美股代码                       |
+| symbols | str | symbols="TSLA,NVDA,AAPL"; 英文逗号分隔的美股代码, 会自动去除空格并转为大写       |
 | source  | str | source="reddit"; choice of {"reddit", "x", "news", "polymarket"} |
 | days    | int | days=7; 最近 N 天数据                                              |
 | api_key | str | api_key=""; Adanos API Key, 也可以设置环境变量 `ADANOS_API_KEY`          |

--- a/tests/test_stock_us_adanos.py
+++ b/tests/test_stock_us_adanos.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+"""
+Date: 2026/05/03
+Desc: test stock_us_adanos.py
+"""
+
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+
+from akshare.stock.stock_us_adanos import (
+    stock_us_adanos_compare,
+    stock_us_adanos_sentiment,
+)
+
+
+def test_stock_us_adanos_sentiment():
+    """
+    test stock_us_adanos_sentiment
+    :return: None
+    :rtype: None
+    """
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "ticker": "TSLA",
+        "company_name": "Tesla Inc.",
+        "buzz_score": 72.4,
+        "trend": "rising",
+        "sentiment_score": 0.31,
+        "mentions": 128,
+        "trend_history": [61.0, 66.0, 72.4],
+    }
+    mock_response.raise_for_status.return_value = None
+
+    with patch(
+        "akshare.stock.stock_us_adanos.requests.get", return_value=mock_response
+    ) as mock_get:
+        temp_df = stock_us_adanos_sentiment(
+            symbol="tsla", source="reddit", days=3, api_key="test-key"
+        )
+
+    assert isinstance(temp_df, pd.DataFrame)
+    assert temp_df.loc[0, "source"] == "reddit"
+    assert temp_df.loc[0, "ticker"] == "TSLA"
+    assert temp_df.loc[0, "buzz_score"] == 72.4
+    assert temp_df.loc[0, "trend_history"] == [61.0, 66.0, 72.4]
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"] == {"days": 3}
+    assert kwargs["headers"]["X-API-Key"] == "test-key"
+    assert kwargs["timeout"] == 30
+
+
+def test_stock_us_adanos_compare():
+    """
+    test stock_us_adanos_compare
+    :return: None
+    :rtype: None
+    """
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "stocks": [
+            {
+                "ticker": "TSLA",
+                "company_name": "Tesla Inc.",
+                "buzz_score": 72.4,
+                "trend": "rising",
+            },
+            {
+                "ticker": "NVDA",
+                "company_name": "NVIDIA Corporation",
+                "buzz_score": 68.2,
+                "trend": "stable",
+            },
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    with patch(
+        "akshare.stock.stock_us_adanos.requests.get", return_value=mock_response
+    ) as mock_get:
+        temp_df = stock_us_adanos_compare(
+            symbols="tsla,nvda", source="news", days=7, api_key="test-key"
+        )
+
+    assert list(temp_df["ticker"]) == ["TSLA", "NVDA"]
+    assert list(temp_df["source"]) == ["news", "news"]
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"] == {"tickers": "TSLA,NVDA", "days": 7}
+
+
+def test_stock_us_adanos_invalid_source():
+    """
+    test stock_us_adanos invalid source
+    :return: None
+    :rtype: None
+    """
+    with pytest.raises(ValueError, match="source must be one of"):
+        stock_us_adanos_sentiment(source="invalid", api_key="test-key")
+
+
+def test_stock_us_adanos_requires_api_key(monkeypatch):
+    """
+    test stock_us_adanos requires api key
+    :return: None
+    :rtype: None
+    """
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="Please provide api_key"):
+        stock_us_adanos_compare(api_key="")
+
+
+def test_stock_us_adanos_env_api_key(monkeypatch):
+    """
+    test stock_us_adanos uses environment api key
+    :return: None
+    :rtype: None
+    """
+    mock_response = Mock()
+    mock_response.json.return_value = {"stocks": []}
+    mock_response.raise_for_status.return_value = None
+    monkeypatch.setenv("ADANOS_API_KEY", "env-key")
+
+    with patch(
+        "akshare.stock.stock_us_adanos.requests.get", return_value=mock_response
+    ) as mock_get:
+        stock_us_adanos_compare(api_key="")
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["headers"]["X-API-Key"] == "env-key"

--- a/tests/test_stock_us_adanos.py
+++ b/tests/test_stock_us_adanos.py
@@ -7,6 +7,7 @@ Desc: test stock_us_adanos.py
 
 from unittest.mock import Mock, patch
 
+import akshare as ak
 import pandas as pd
 import pytest
 
@@ -38,7 +39,7 @@ def test_stock_us_adanos_sentiment():
         "akshare.stock.stock_us_adanos.requests.get", return_value=mock_response
     ) as mock_get:
         temp_df = stock_us_adanos_sentiment(
-            symbol="tsla", source="reddit", days=3, api_key="test-key"
+            symbol=" tsla ", source=" Reddit ", days=3, api_key="test-key"
         )
 
     assert isinstance(temp_df, pd.DataFrame)
@@ -47,8 +48,10 @@ def test_stock_us_adanos_sentiment():
     assert temp_df.loc[0, "buzz_score"] == 72.4
     assert temp_df.loc[0, "trend_history"] == [61.0, 66.0, 72.4]
 
-    _, kwargs = mock_get.call_args
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://api.adanos.org/reddit/stocks/v1/stock/TSLA"
     assert kwargs["params"] == {"days": 3}
+    assert kwargs["headers"]["Accept"] == "application/json"
     assert kwargs["headers"]["X-API-Key"] == "test-key"
     assert kwargs["timeout"] == 30
 
@@ -82,14 +85,25 @@ def test_stock_us_adanos_compare():
         "akshare.stock.stock_us_adanos.requests.get", return_value=mock_response
     ) as mock_get:
         temp_df = stock_us_adanos_compare(
-            symbols="tsla,nvda", source="news", days=7, api_key="test-key"
+            symbols="tsla, nvda, ", source="news", days=7, api_key="test-key"
         )
 
     assert list(temp_df["ticker"]) == ["TSLA", "NVDA"]
     assert list(temp_df["source"]) == ["news", "news"]
 
-    _, kwargs = mock_get.call_args
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://api.adanos.org/news/stocks/v1/compare"
     assert kwargs["params"] == {"tickers": "TSLA,NVDA", "days": 7}
+
+
+def test_stock_us_adanos_root_exports():
+    """
+    test stock_us_adanos root exports
+    :return: None
+    :rtype: None
+    """
+    assert ak.stock_us_adanos_sentiment is stock_us_adanos_sentiment
+    assert ak.stock_us_adanos_compare is stock_us_adanos_compare
 
 
 def test_stock_us_adanos_invalid_source():
@@ -102,6 +116,26 @@ def test_stock_us_adanos_invalid_source():
         stock_us_adanos_sentiment(source="invalid", api_key="test-key")
 
 
+def test_stock_us_adanos_empty_symbol():
+    """
+    test stock_us_adanos empty symbol
+    :return: None
+    :rtype: None
+    """
+    with pytest.raises(ValueError, match="symbol must not be empty"):
+        stock_us_adanos_sentiment(symbol=" ", api_key="test-key")
+
+
+def test_stock_us_adanos_empty_symbols():
+    """
+    test stock_us_adanos empty symbols
+    :return: None
+    :rtype: None
+    """
+    with pytest.raises(ValueError, match="symbols must contain"):
+        stock_us_adanos_compare(symbols=" , ", api_key="test-key")
+
+
 def test_stock_us_adanos_requires_api_key(monkeypatch):
     """
     test stock_us_adanos requires api key
@@ -110,7 +144,7 @@ def test_stock_us_adanos_requires_api_key(monkeypatch):
     """
     monkeypatch.delenv("ADANOS_API_KEY", raising=False)
     with pytest.raises(ValueError, match="Please provide api_key"):
-        stock_us_adanos_compare(api_key="")
+        stock_us_adanos_compare(api_key=" ")
 
 
 def test_stock_us_adanos_env_api_key(monkeypatch):


### PR DESCRIPTION
## Summary
- add optional Adanos Market Sentiment API support for US stocks
- expose `stock_us_adanos_sentiment` and `stock_us_adanos_compare` from `akshare`
- support Reddit, X, News, and Polymarket sources via explicit `api_key` or `ADANOS_API_KEY`
- document usage and add mocked tests for request parameters, validation, and env-key fallback

## Validation
- `.venv/bin/python -m pytest tests/test_stock_us_adanos.py -q`
- `.venv/bin/python -m py_compile akshare/stock/stock_us_adanos.py tests/test_stock_us_adanos.py`
- `.venv/bin/ruff check akshare/stock/stock_us_adanos.py tests/test_stock_us_adanos.py`
- `.venv/bin/ruff format --check akshare/stock/stock_us_adanos.py tests/test_stock_us_adanos.py`
- `git diff --check`
