### PR TITLE
feat: add cninfo hk dividend interface

### DIFF
--- a/akshare/__init__.py
+++ b/akshare/__init__.py
@@ -4301,6 +4301,11 @@ from akshare.stock.stock_new_cninfo import (
 from akshare.stock.stock_dividend_cninfo import stock_dividend_cninfo
 
 """
+港股分红派息
+"""
+from akshare.stock.stock_hk_dividend_cninfo import stock_hk_dividend_cninfo
+
+"""
 公司股本变动
 """
 from akshare.stock.stock_share_changes_cninfo import stock_share_change_cninfo

--- a/akshare/stock/stock_hk_dividend_cninfo.py
+++ b/akshare/stock/stock_hk_dividend_cninfo.py
@@ -78,7 +78,7 @@ def stock_hk_dividend_cninfo(
     }
     r = requests.get(url, params=params, headers=headers, timeout=15)
     data_json = r.json()
-    temp_df = pd.DataFrame(data_json["records"])
+    temp_df = pd.DataFrame(data_json.get("records", []))
     if temp_df.empty:
         return temp_df
     temp_df.rename(

--- a/akshare/stock/stock_hk_dividend_cninfo.py
+++ b/akshare/stock/stock_hk_dividend_cninfo.py
@@ -1,0 +1,155 @@
+# -*- coding:utf-8 -*-
+# !/usr/bin/env python
+"""
+Date: 2026/04/30 12:00
+Desc: 巨潮资讯-港股-重要指标-分红派息表
+https://webapi.cninfo.com.cn/#/apiDoc
+"""
+
+import pandas as pd
+import py_mini_racer
+import requests
+
+from akshare.datasets import get_ths_js
+
+
+def _get_file_content_cninfo(file: str = "cninfo.js") -> str:
+    """
+    获取 JS 文件的内容
+    :param file:  JS 文件名
+    :type file: str
+    :return: 文件内容
+    :rtype: str
+    """
+    setting_file_path = get_ths_js(file)
+    with open(setting_file_path, encoding="utf-8") as f:
+        file_data = f.read()
+    return file_data
+
+
+def stock_hk_dividend_cninfo(
+    symbol: str = "00700",
+    start_date: str = "19000101",
+    end_date: str = "21000101",
+    state: str = "1",
+) -> pd.DataFrame:
+    """
+    巨潮资讯-港股-重要指标-分红派息表
+    https://webapi.cninfo.com.cn/#/apiDoc
+    查询 p_hk4018 接口
+    :param symbol: 港股代码
+    :type symbol: str
+    :param start_date: 开始查询时间
+    :type start_date: str
+    :param end_date: 结束查询时间
+    :type end_date: str
+    :param state: 查询状态; 1: 历史所有数据; 2: 最近一次数据
+    :type state: str
+    :return: 分红派息表
+    :rtype: pandas.DataFrame
+    """
+    symbol = symbol.zfill(5)
+    url = "https://webapi.cninfo.com.cn/api/hk/p_hk4018"
+    params = {
+        "scode": symbol,
+        "sdate": "-".join([start_date[:4], start_date[4:6], start_date[6:]]),
+        "edate": "-".join([end_date[:4], end_date[4:6], end_date[6:]]),
+        "state": state,
+    }
+    js_code = py_mini_racer.MiniRacer()
+    js_content = _get_file_content_cninfo("cninfo.js")
+    js_code.eval(js_content)
+    mcode = js_code.call("getResCode1")
+    headers = {
+        "Accept": "*/*",
+        "Accept-Enckey": mcode,
+        "Accept-Encoding": "gzip, deflate",
+        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Host": "webapi.cninfo.com.cn",
+        "Origin": "https://webapi.cninfo.com.cn",
+        "Pragma": "no-cache",
+        "Proxy-Connection": "keep-alive",
+        "Referer": "https://webapi.cninfo.com.cn/",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/93.0.4577.63 Safari/537.36",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+    r = requests.get(url, params=params, headers=headers, timeout=15)
+    data_json = r.json()
+    temp_df = pd.DataFrame(data_json["records"])
+    if temp_df.empty:
+        return temp_df
+    temp_df.rename(
+        columns={
+            "SECCODE": "证券代码",
+            "SECNAME": "证券简称",
+            "F001D": "公告日期",
+            "F002D": "分红年度",
+            "F003V": "事项类型",
+            "F004V": "事项",
+            "F005D": "股权登记日",
+            "F006D": "除净日",
+            "F007D": "开始截止过户日期",
+            "F008D": "最后截止过户日期",
+            "F009D": "派息日",
+            "F010N": "每股派息",
+            "F011V": "每股派息币种",
+            "F012N": "派息比例",
+            "F013N": "派息比例值",
+            "F015V": "币种",
+            "F044V": "实物分派说明",
+            "F046V": "派息方式",
+            "MEMO": "备注",
+        },
+        inplace=True,
+    )
+    date_cols = [
+        "公告日期",
+        "分红年度",
+        "股权登记日",
+        "除净日",
+        "开始截止过户日期",
+        "最后截止过户日期",
+        "派息日",
+    ]
+    for item in date_cols:
+        temp_df[item] = pd.to_datetime(temp_df[item], errors="coerce").dt.date
+    numeric_cols = ["每股派息", "派息比例", "派息比例值"]
+    for item in numeric_cols:
+        temp_df[item] = pd.to_numeric(temp_df[item], errors="coerce")
+    temp_df = temp_df[
+        [
+            "证券代码",
+            "证券简称",
+            "公告日期",
+            "分红年度",
+            "事项类型",
+            "事项",
+            "股权登记日",
+            "除净日",
+            "开始截止过户日期",
+            "最后截止过户日期",
+            "派息日",
+            "每股派息",
+            "每股派息币种",
+            "派息比例",
+            "派息比例值",
+            "币种",
+            "派息方式",
+            "实物分派说明",
+            "备注",
+        ]
+    ]
+    temp_df.sort_values(by="公告日期", ignore_index=True, inplace=True)
+    return temp_df
+
+
+if __name__ == "__main__":
+    stock_hk_dividend_cninfo_df = stock_hk_dividend_cninfo(
+        symbol="00700",
+        start_date="20200101",
+        end_date="20260101",
+    )
+    print(stock_hk_dividend_cninfo_df)

--- a/docs/data/stock/stock.md
+++ b/docs/data/stock/stock.md
@@ -5236,6 +5236,80 @@ print(stock_hk_dividend_payout_em_df)
 [19 rows x 7 columns]
 ```
 
+#### 分红派息-巨潮资讯
+
+接口: stock_hk_dividend_cninfo
+
+目标地址: https://webapi.cninfo.com.cn/#/apiDoc
+
+描述: 巨潮资讯-港股-重要指标-分红派息表
+
+限量: 单次返回指定港股的分红派息数据
+
+输入参数
+
+| 名称         | 类型  | 描述                                  |
+|------------|-----|-------------------------------------|
+| symbol     | str | symbol="00700"; 港股代码, 5 位代码       |
+| start_date | str | start_date="20200101"; 开始查询时间      |
+| end_date   | str | end_date="20260101"; 结束查询时间        |
+| state      | str | state="1"; 1: 历史所有数据; 2: 最近一次数据 |
+
+输出参数
+
+| 名称       | 类型      | 描述 |
+|----------|---------|----|
+| 证券代码     | object  | -  |
+| 证券简称     | object  | -  |
+| 公告日期     | object  | -  |
+| 分红年度     | object  | -  |
+| 事项类型     | object  | -  |
+| 事项       | object  | -  |
+| 股权登记日    | object  | -  |
+| 除净日      | object  | -  |
+| 开始截止过户日期 | object  | -  |
+| 最后截止过户日期 | object  | -  |
+| 派息日      | object  | -  |
+| 每股派息     | float64 | -  |
+| 每股派息币种   | object  | -  |
+| 派息比例     | float64 | -  |
+| 派息比例值    | float64 | -  |
+| 币种       | object  | -  |
+| 派息方式     | object  | -  |
+| 实物分派说明   | object  | -  |
+| 备注       | object  | -  |
+
+接口示例
+
+```python
+import akshare as ak
+
+stock_hk_dividend_cninfo_df = ak.stock_hk_dividend_cninfo(
+    symbol="00700",
+    start_date="20200101",
+    end_date="20260101",
+)
+print(stock_hk_dividend_cninfo_df)
+```
+
+数据示例
+
+```
+     证券代码  证券简称        公告日期  ... 派息方式 实物分派说明    备注
+0   00700  腾讯控股  2020-03-18  ...   现金    NaN  None
+1   00700  腾讯控股  2020-05-13  ...  NaN    NaN  None
+2   00700  腾讯控股  2020-08-12  ...  NaN    NaN  None
+3   00700  腾讯控股  2020-11-12  ...  NaN    NaN  None
+4   00700  腾讯控股  2021-03-24  ...   现金    NaN  None
+..    ...   ...         ...  ...  ...    ...   ...
+21  00700  腾讯控股  2024-11-13  ...  NaN    NaN  None
+22  00700  腾讯控股  2025-03-19  ...   现金    NaN  None
+23  00700  腾讯控股  2025-05-14  ...  NaN    NaN  None
+24  00700  腾讯控股  2025-08-13  ...  NaN    NaN  None
+25  00700  腾讯控股  2025-11-13  ...  NaN    NaN  None
+[26 rows x 19 columns]
+```
+
 
 #### 行业对比
 


### PR DESCRIPTION
## Summary

- Add `stock_hk_dividend_cninfo` for HK dividend payout data from CNInfo
- Export the new interface in `akshare.__init__`
- Add documentation and usage example
- Handle CNInfo responses without `records` by returning an empty DataFrame

## Test

```bash
python3 -m ruff check akshare/stock/stock_hk_dividend_cninfo.py
python3 -m ruff format --check akshare/stock/stock_hk_dividend_cninfo.py
```

Runtime check:
```Python
import akshare as ak

df = ak.stock_hk_dividend_cninfo(
    symbol="00700",
    start_date="20200101",
    end_date="20260101",
)
print(df.shape)

# Result: (26, 19)
```