### PR TITLE
fix: handle empty cninfo disclosure reports

### DIFF
--- a/akshare/stock_feature/stock_disclosure_cninfo.py
+++ b/akshare/stock_feature/stock_disclosure_cninfo.py
@@ -145,6 +145,10 @@ def stock_zh_a_disclosure_report_cninfo(
     r = requests.post(url, params=payload)
     text_json = r.json()
     page_num = math.ceil(int(text_json["totalAnnouncement"]) / 30)
+    if page_num == 0:
+        return pd.DataFrame(
+            columns=["代码", "简称", "公告标题", "公告时间", "公告链接"]
+        )
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(1, page_num + 1), leave=False):


### PR DESCRIPTION
## Summary

- Handle empty CNInfo disclosure query results in `stock_zh_a_disclosure_report_cninfo`
- Return an empty DataFrame with expected columns instead of raising `KeyError`

Fixes #7251

## Test

```bash
python3 -m ruff check akshare/stock_feature/stock_disclosure_cninfo.py
python3 -m ruff format --check akshare/stock_feature/stock_disclosure_cninfo.py
python3 -m compileall -q akshare/stock_feature/stock_disclosure_cninfo.py
```

Runtime check:
```python
import akshare as ak

df = ak.stock_zh_a_disclosure_report_cninfo(
    symbol="600036",
    market="沪深京",
    category="风险提示",
    start_date="20200101",
    end_date="20260428",
)

print(df.shape)
print(df.columns.tolist())
# Result: (0, 5)
# Columns: ['代码', '简称', '公告标题', '公告时间', '公告链接']
```