### PR TITLE
fix: stock_zh_a_disclosure_{report,relation}_cninfo

### DIFF
--- a/akshare/stock_feature/stock_disclosure_cninfo.py
+++ b/akshare/stock_feature/stock_disclosure_cninfo.py
@@ -119,7 +119,7 @@ def stock_zh_a_disclosure_report_cninfo(
         "预披露": "pre_disclosure",
     }
     stock_id_map = ""
-    if market == "沪深京" or "基金":
+    if market in ("沪深京", "基金"):
         stock_id_map = __get_stock_json(market)
     category_dict = __get_category_dict()
     url = "http://www.cninfo.com.cn/new/hisAnnouncement/query"
@@ -216,8 +216,8 @@ def stock_zh_a_disclosure_relation_cninfo(
         "预披露": "pre_disclosure",
     }
     stock_id_map = ""
-    if market == "沪深京":
-        stock_id_map = __get_stock_json(symbol)
+    if market in ("沪深京", "基金"):
+        stock_id_map = __get_stock_json(market)
     stock_item = "" if symbol == "" else f"{symbol},{stock_id_map[symbol]}"
     url = "http://www.cninfo.com.cn/new/hisAnnouncement/query"
     payload = {
@@ -240,6 +240,10 @@ def stock_zh_a_disclosure_relation_cninfo(
     r = requests.post(url, data=payload)
     text_json = r.json()
     page_num = math.ceil(int(text_json["totalAnnouncement"]) / 30)
+    if page_num == 0:
+        return pd.DataFrame(
+            columns=["代码", "简称", "公告标题", "公告时间", "公告链接"]
+        )
     big_df = pd.DataFrame()
     tqdm = get_tqdm()
     for page in tqdm(range(1, page_num + 1), leave=False):
@@ -264,7 +268,7 @@ def stock_zh_a_disclosure_relation_cninfo(
     big_df["公告时间"] = (
         big_df["公告时间"]
         .dt.tz_convert("Asia/Shanghai")
-        .dt.tz_convert(None)
+        .dt.tz_localize(None)
         .astype(str)
     )
     url_list = []


### PR DESCRIPTION
## Summary

修复 `stock_zh_a_disclosure_relation_cninfo` 三处问题, 与 `stock_zh_a_disclosure_report_cninfo` (#7254) 行为对齐. 顺带修正两函数共有的 `if market == "沪深京" or "基金":` 语法 bug.

### `stock_zh_a_disclosure_relation_cninfo` 三处修复

1. `if market == "沪深京":` 且 `__get_stock_json(symbol)` 误用 symbol 参数, 与 report 函数对齐改为白名单 + `__get_stock_json(market)`. 修复 `market="基金"` 路径下 `stock_id_map=""` 引发的 `TypeError: string indices must be integers`
2. `totalAnnouncement=0` 时提前返回空 DataFrame, 避免末尾按列重排引发 KeyError (与 #7251 / #7254 同模式)
3. 公告时间改用 `dt.tz_localize(None)` 而非 `dt.tz_convert(None)`. `tz_convert(None)` 会把 Asia/Shanghai 时间转回 UTC, 实测公告原始时间戳上海 16:37 在当前代码返回 08:37 (偏差 8 小时); `tz_localize(None)` 才是丢掉时区信息保留 wall-clock

### `stock_zh_a_disclosure_report_cninfo` 一处修复

`if market == "沪深京" or "基金":` 因运算符优先级实际等价于 `if (market == "沪深京") or "基金":`, 表达式恒真. 对 `market="监管"` / `"预披露"` 等 `__get_stock_json` 没有 elif 的 market, 会 fall through 到默认 A 股 stock list, 将错误的 A 股 orgId 拼入请求 silently 返错. 改为白名单 `if market in ("沪深京", "基金"):` 与原始意图对齐, 不扩展未测试的 market 范围.

## Test

```bash
ruff check akshare/stock_feature/stock_disclosure_cninfo.py
ruff format --check akshare/stock_feature/stock_disclosure_cninfo.py
python3 -m compileall -q akshare/stock_feature/stock_disclosure_cninfo.py
```

Runtime check (节选):

```python
import akshare as ak

# 1. relation 空路径不再 KeyError
df = ak.stock_zh_a_disclosure_relation_cninfo(
    symbol="600036", market="沪深京",
    start_date="20200101", end_date="20200131",
)
# shape=(0, 5)

# 2. relation market="基金" 跑通 (原作者本意场景, 之前 TypeError)
df = ak.stock_zh_a_disclosure_relation_cninfo(
    symbol="164701", market="基金",
    start_date="20240101", end_date="20240601",
)
# shape=(0, 5) 该窗口无内容

# 3. relation 时区为北京时间 (修复前: UTC, 偏差 8 小时)
df = ak.stock_zh_a_disclosure_relation_cninfo(
    symbol="000001", market="沪深京",
    start_date="20231201", end_date="20240101",
)
# 2023-12-27 16:37:17

# 4. report market="基金" 跑通拿到真数据
df = ak.stock_zh_a_disclosure_report_cninfo(
    symbol="164701", market="基金", category="",
    start_date="20240101", end_date="20240601",
)
# shape=(11, 5)

# 5. relation/report market="监管" 维持显式 TypeError
#    (与原代码行为一致, 不引入静默失败)
```

Related: #7251, #7254