### PR TITLE
fix(macro_china_nbs): 切到新版 NBS API (关 #7180 #7211 #7216)

### DIFF
--- a/akshare/economic/macro_china_nbs.py
+++ b/akshare/economic/macro_china_nbs.py
@@ -1,149 +1,916 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 """
-Date: 2024/6/30 22:00
+Date: 2026/5/8 10:00
 Desc: 中国-国家统计局-宏观数据
-https://data.stats.gov.cn/easyquery.htm
+https://data.stats.gov.cn/dg/website/
+
+NBS 在 2026 年改版后, 老 easyquery.htm 端点被 WAF 拉黑名单 (reason:UrlACL),
+本模块改走新版 /dg/website/publicrelease/web/external/* GUID 体系直连.
+
+对外签名 (macro_china_nbs_nation / macro_china_nbs_region) 与旧版兼容.
+内部解析 path 中文名到 GUID, 并支持 leaf 节点的多时间切片 fallback.
+
+修复 issues: #7180 #7211 #7216
 """
 
-import time
+import json
+import re
 from functools import lru_cache
-from typing import Union, Literal, List, Dict
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
-import jsonpath as jp
-import numpy as np
 import pandas as pd
 import requests
-import urllib3
-from urllib3.exceptions import InsecureRequestWarning
 
-# 忽略InsecureRequestWarning警告
-urllib3.disable_warnings(InsecureRequestWarning)
+# ============ 常量 ============
+
+NBS_BASE = "https://data.stats.gov.cn/dg/website/publicrelease/web/external"
+
+# 12 个 dataset 根节点 (探测得到, 老版只暴露 10 种 kind)
+_DATASETS: Dict[str, Dict[str, str]] = {
+    "1": {"name": "月度数据", "root_id": "fc982599aa684be7969d7b90b1bd0e84"},
+    "2": {"name": "季度数据", "root_id": "a94b8b7365a94874968cabbe392cf679"},
+    "3": {"name": "年度数据", "root_id": "884c062607104a91967b22742537f44f"},
+    "4": {"name": "分省月度数据", "root_id": "f4c6cd795fea436c807163397dd36b98"},
+    "5": {"name": "分省季度数据", "root_id": "854f819b04104191a5ae2f2cba270e6c"},
+    "6": {"name": "分省年度数据", "root_id": "c4d82af16c3d4f0cb4f09d4af7d5888e"},
+    "7": {"name": "主要城市月度价格", "root_id": "327ecbb2e6b14c669da1e99e39faa24c"},
+    "8": {"name": "主要城市年度数据", "root_id": "2d06bab01494417e9052ef0f8d93e23e"},
+    "9": {"name": "港澳台月度数据", "root_id": "bbf7c2c592a140e295423bc2e7f5cd36"},
+    "10": {"name": "港澳台年度数据", "root_id": "df5df037aa03435888766cde0aa303dd"},
+}
+_KIND_TO_CODE: Dict[str, str] = {m["name"]: c for c, m in _DATASETS.items()}
+
+# kind → period 后缀 (月度 MM / 季度 SS 序号 01-04 / 年度 YY)
+_KIND_TO_SUFFIX: Dict[str, str] = {
+    "月度数据": "MM",
+    "分省月度数据": "MM",
+    "季度数据": "SS",
+    "分省季度数据": "SS",
+    "年度数据": "YY",
+    "分省年度数据": "YY",
+    "主要城市月度价格": "MM",
+    "主要城市年度数据": "YY",
+    "港澳台月度数据": "MM",
+    "港澳台年度数据": "YY",
+}
+
+_HTTP_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Origin": "https://data.stats.gov.cn",
+    "Referer": "https://data.stats.gov.cn/dg/website/page.html",
+}
+
+_session: Optional[requests.Session] = None
 
 
-@lru_cache
-def _get_nbs_tree(idcode: str, dbcode: str) -> List[Dict]:
+def _get_session() -> requests.Session:
+    """Lazy 持久 Session — 必须 lazy, 绝不 import-time 网络请求.
+
+    NBS WAF 偶发会 307 + Set-Cookie (wzws_cid) challenge, 持久 Session
+    自动 carry cookie 跟随 redirect.
     """
-    获取指标目录树
-    :param idcode: 指标编码
-    :param dbcode: 库编码
-    :return:  json数据
-    """
-    url = "https://data.stats.gov.cn/easyquery.htm"
-    params = {"id": idcode, "dbcode": dbcode, "wdcode": "zb", "m": "getTree"}
-    r = requests.post(url, params=params, verify=False, allow_redirects=True)
-    data_json = r.json()
-    return data_json
+    global _session
+    if _session is None:
+        s = requests.Session()
+        s.headers.update(_HTTP_HEADERS)
+        try:
+            s.get("https://data.stats.gov.cn/dg/website/page.html", timeout=15)
+        except requests.RequestException:
+            pass
+        _session = s
+    return _session
 
 
-@lru_cache
-def _get_nbs_wds_tree(idcode: str, dbcode: str, rowcode: str) -> List[Dict]:
+def _request_json(method: str, url: str, **kwargs) -> Union[dict, list]:
+    """统一 HTTP 请求 + JSON 解析 + WAF 检测.
+
+    NBS WAF 在错误请求 (例 dts 字符串形态而非 list) 时返 200 + HTML 而不是 JSON,
+    必须显式检查 Content-Type.
     """
-    获取地区数据的可选指标目录树
-    :param idcode: 指标编码
-    :param dbcode: 库编码
-    :param rowcode: 值为zb是返回地区的编码，值为reg时返回可选指标的编码
-    :return:  json数据
+    s = _get_session()
+    kwargs.setdefault("timeout", 30)
+    resp = s.request(method, url, **kwargs)
+    resp.raise_for_status()
+    ctype = resp.headers.get("Content-Type", "").lower()
+    if "html" in ctype or resp.text.lstrip().startswith("<"):
+        raise RuntimeError(
+            "NBS WAF 拦截 (返 HTML 而非 JSON), 请检查请求参数 (例 dts 必须是 list)"
+        )
+    return resp.json()
+
+
+# ============ 名字归一 + leaf 时间切片解析 ============
+
+
+def _normalize(name: Optional[str]) -> str:
+    """归一 NBS 节点名用于比较.
+
+    NBS 改版后 catalog name 加了空格 (例 '居民消费价格分类指数 (上年同月=100) ');
+    老版用户传值习惯 '居民消费价格分类指数(上年同月=100)' 或 '地区生产总值_累计值(亿元)'.
+    比较时双方都 normalize 才能稳定匹配.
     """
-    url = "https://data.stats.gov.cn/easyquery.htm"
-    params = {
-        "m": "getOtherWds",
-        "dbcode": dbcode,
-        "rowcode": rowcode,
-        "colcode": "sj",
-        "wds": '[{"wdcode":"zb","valuecode":"%s"}]' % idcode,
-        "k1": str(time.time_ns())[:13],
+    if not name:
+        return ""
+    n = name.replace(" ", "").replace("　", "")
+    n = n.replace("（", "(").replace("）", ")").replace("：", ":")
+    n = n.replace("_", "")
+    return n
+
+
+_PERIOD_TAIL = re.compile(r"\s*[\(（]\s*(\d{4})?\s*[-—]\s*(\d{4}|至今)?\s*[\)）]\s*$")
+
+
+def _strip_period_tail(name: str) -> str:
+    """去掉末尾时间切片括号. 输入应已 normalized."""
+    return _PERIOD_TAIL.sub("", name).strip()
+
+
+def _parse_slice_range(name: str) -> Optional[Tuple[Optional[int], Optional[int]]]:
+    """从 leaf 名末尾切片括号解析时间范围, 返 (start, end) 或 None."""
+    m = _PERIOD_TAIL.search(name)
+    if not m:
+        return None
+    s, e = m.group(1), m.group(2)
+    start = int(s) if s else None
+    end = int(e) if (e and e != "至今") else None
+    return (start, end)
+
+
+# ============ Period 解析 (老版兼容) ============
+
+# 老版文档支持: last10 (大小写) / 201201,201205 / 2012A-D / 2012,2013 / 2013-
+_RE_LAST = re.compile(r"^last(\d+)$", re.IGNORECASE)
+_RE_RANGE_DASH = re.compile(r"^(\d{4})-(\d{4})?$")
+_RE_SINGLE_YEAR = re.compile(r"^(\d{4})$")
+_RE_MONTH_TOKEN = re.compile(r"^(\d{4})(\d{2})$")
+_RE_QUARTER_TOKEN = re.compile(r"^(\d{4})([ABCD])$", re.IGNORECASE)
+_QUARTER_LETTER_TO_IDX = {"A": 1, "B": 2, "C": 3, "D": 4}
+
+
+def _parse_user_period(period: Optional[str]) -> Dict[str, object]:
+    """解析用户 period 字符串成结构化字典.
+
+    支持格式 (与老版 docstring 对齐):
+        None / 'last10' / 'LAST10'    → {kind: LATEST, n}
+        '2018-2023'                    → {kind: RANGE, start, end}
+        '2018-'                        → {kind: OPEN_RANGE, start}
+        '2018'                         → {kind: SINGLE, year}
+        '201201,201205'  (月度逗号)    → {kind: DISCRETE_MONTH, codes}
+        '2012A,2012B'    (季度逗号)    → {kind: DISCRETE_QUARTER, codes}
+        '2012,2013'      (年度逗号)    → {kind: DISCRETE_YEAR, codes}
+    """
+    if period is None or not period.strip():
+        return {"kind": "LATEST", "n": 13}
+    p = period.strip()
+
+    m = _RE_LAST.match(p)
+    if m:
+        n = int(m.group(1))
+        if n < 1:
+            raise ValueError(f"last_N 必须 >= 1, 得到 {period!r}")
+        return {"kind": "LATEST", "n": n}
+
+    if "," in p:
+        tokens = [t.strip() for t in p.split(",") if t.strip()]
+        if all(_RE_MONTH_TOKEN.match(t) for t in tokens):
+            codes = [
+                (
+                    int(_RE_MONTH_TOKEN.match(t).group(1)),
+                    int(_RE_MONTH_TOKEN.match(t).group(2)),
+                )
+                for t in tokens
+            ]
+            invalid_months = [(y, m) for y, m in codes if not 1 <= m <= 12]
+            if invalid_months:
+                raise ValueError(
+                    f"period 月度离散值含非法月份 {invalid_months}, 月份必须 1-12"
+                )
+            return {"kind": "DISCRETE_MONTH", "codes": codes}
+        if all(_RE_QUARTER_TOKEN.match(t) for t in tokens):
+            codes = [
+                (
+                    int(_RE_QUARTER_TOKEN.match(t).group(1)),
+                    _QUARTER_LETTER_TO_IDX[_RE_QUARTER_TOKEN.match(t).group(2).upper()],
+                )
+                for t in tokens
+            ]
+            return {"kind": "DISCRETE_QUARTER", "codes": codes}
+        if all(_RE_SINGLE_YEAR.match(t) for t in tokens):
+            return {"kind": "DISCRETE_YEAR", "codes": [int(t) for t in tokens]}
+        raise ValueError(f"period {period!r} 中逗号离散值类型不一致或格式不识别")
+
+    m = _RE_RANGE_DASH.match(p)
+    if m:
+        start = int(m.group(1))
+        end = m.group(2)
+        if end is None:
+            return {"kind": "OPEN_RANGE", "start": start}
+        return {"kind": "RANGE", "start": start, "end": int(end)}
+
+    m = _RE_SINGLE_YEAR.match(p)
+    if m:
+        return {"kind": "SINGLE", "year": int(m.group(1))}
+
+    raise ValueError(f"无法识别的 period 格式: {period!r}")
+
+
+# ============ NBS period code 转换 ============
+
+
+def _parse_nbs_code(code: str) -> Tuple[int, int, str]:
+    """NBS code → (year, sub_index, suffix). 例: 202604MM → (2026, 4, MM)."""
+    m = re.match(r"^(\d{4})(\d{2})(MM|SS)$", code)
+    if m:
+        return int(m.group(1)), int(m.group(2)), m.group(3)
+    m = re.match(r"^(\d{4})YY$", code)
+    if m:
+        return int(m.group(1)), 0, "YY"
+    raise ValueError(f"无法解析 NBS period code: {code!r}")
+
+
+def _shift_period(year: int, sub: int, suffix: str, n_back: int) -> Tuple[int, int]:
+    """从 (year, sub) 往前推 n_back 期."""
+    if suffix == "YY":
+        return (year - n_back, 0)
+    units = 12 if suffix == "MM" else 4
+    total = year * units + (sub - 1) - n_back
+    return (total // units, total % units + 1)
+
+
+def _fmt_nbs_code(year: int, sub: int, suffix: str) -> str:
+    if suffix == "YY":
+        return f"{year}YY"
+    return f"{year:04d}{sub:02d}{suffix}"
+
+
+def _is_period_after(a: Tuple[int, int], b: Tuple[int, int], suffix: str) -> bool:
+    if suffix == "YY":
+        return a[0] > b[0]
+    return (a[0], a[1]) > (b[0], b[1])
+
+
+def _period_to_dts(
+    kind: str, user_period: Dict[str, object], latest_code: str
+) -> List[str]:
+    """老 period → 新版 dts list. 含越界 clamp + start>latest fail-fast.
+
+    新版后端能服务端过滤 dts list (字符串形态被 WAF 拒).
+    右端超过 latest 会被 clamp 到 latest (避免拉到未发布的空期).
+    start > latest / start > end 直接 fail-fast.
+    """
+    suffix = _KIND_TO_SUFFIX[kind]
+    ey, es, _ = _parse_nbs_code(latest_code)
+    pkind = user_period["kind"]
+
+    # 离散 period 必须跟 kind 后缀一致 (例 月度 kind 不能用 '2012,2013' 年度逗号)
+    _DISCRETE_REQUIRED_SUFFIX = {
+        "DISCRETE_YEAR": "YY",
+        "DISCRETE_MONTH": "MM",
+        "DISCRETE_QUARTER": "SS",
     }
-    r = requests.post(url, params=params, verify=False, allow_redirects=True)
-    data_json = r.json()
-    data_json = data_json["returndata"][0]["nodes"]
-    return data_json
+    if pkind in _DISCRETE_REQUIRED_SUFFIX:
+        required = _DISCRETE_REQUIRED_SUFFIX[pkind]
+        if required != suffix:
+            kind_label = {"YY": "年度", "MM": "月度", "SS": "季度"}[required]
+            raise ValueError(
+                f"period 离散值是 {kind_label} 格式, 不匹配 kind={kind!r} (期望 {suffix})"
+            )
+
+    def _clamp_end(year: int, sub: int) -> Tuple[int, int]:
+        if suffix == "YY":
+            return (min(year, ey), 0)
+        if _is_period_after((year, sub), (ey, es), suffix):
+            return (ey, es)
+        return (year, sub)
+
+    def _check_start_le(year: int, sub: int):
+        if suffix == "YY":
+            if year > ey:
+                raise ValueError(f"period 起点 {year} 晚于最新有数据期 {latest_code}")
+            return
+        if _is_period_after((year, sub), (ey, es), suffix):
+            raise ValueError(f"period 起点 {year}-{sub} 晚于最新有数据期 {latest_code}")
+
+    if pkind == "LATEST":
+        n = int(user_period["n"])
+        sy, ss = _shift_period(ey, es, suffix, n - 1)
+        if suffix == "YY":
+            return [f"{sy}YY-{ey}YY"]
+        return [f"{_fmt_nbs_code(sy, ss, suffix)}-{_fmt_nbs_code(ey, es, suffix)}"]
+
+    if pkind == "RANGE":
+        sy = int(user_period["start"])
+        eyy = int(user_period["end"])
+        if sy > eyy:
+            raise ValueError(f"period 起点 {sy} 晚于终点 {eyy}, 区间无效")
+        if suffix == "YY":
+            _check_start_le(sy, 0)
+            ce_y, _ = _clamp_end(eyy, 0)
+            return [f"{sy}YY-{ce_y}YY"]
+        if suffix == "MM":
+            _check_start_le(sy, 1)
+            ce_y, ce_s = _clamp_end(eyy, 12)
+            return [f"{sy}01MM-{_fmt_nbs_code(ce_y, ce_s, 'MM')}"]
+        _check_start_le(sy, 1)
+        ce_y, ce_s = _clamp_end(eyy, 4)
+        return [f"{sy}01SS-{_fmt_nbs_code(ce_y, ce_s, 'SS')}"]
+
+    if pkind == "OPEN_RANGE":
+        sy = int(user_period["start"])
+        if suffix == "YY":
+            _check_start_le(sy, 0)
+            return [f"{sy}YY-{ey}YY"]
+        if suffix == "MM":
+            _check_start_le(sy, 1)
+            return [f"{sy}01MM-{_fmt_nbs_code(ey, es, 'MM')}"]
+        _check_start_le(sy, 1)
+        return [f"{sy}01SS-{_fmt_nbs_code(ey, es, 'SS')}"]
+
+    if pkind == "SINGLE":
+        y = int(user_period["year"])
+        # 单年起点不能晚于 latest 起点; 当前年终点 clamp 到 latest 防生成未来 dts
+        if y > ey:
+            raise ValueError(
+                f"period 单年 {y} 晚于最新有数据期 {latest_code}, 无可拉数据"
+            )
+        if suffix == "YY":
+            return [f"{y}YY-{y}YY"]
+        if suffix == "MM":
+            ce_y, ce_s = _clamp_end(y, 12)
+            return [f"{y}01MM-{_fmt_nbs_code(ce_y, ce_s, 'MM')}"]
+        ce_y, ce_s = _clamp_end(y, 4)
+        return [f"{y}01SS-{_fmt_nbs_code(ce_y, ce_s, 'SS')}"]
+
+    if pkind == "DISCRETE_YEAR":
+        codes = sorted(set(user_period["codes"]))
+        # 离散值任何一个晚于 latest 都 fail-fast (而不是静默返未来空 dts)
+        future = [y for y in codes if y > ey]
+        if future:
+            raise ValueError(
+                f"period 离散年 {future} 晚于最新有数据期 {latest_code}, 无可拉数据"
+            )
+        return [f"{y}YY-{y}YY" for y in codes]
+
+    if pkind == "DISCRETE_MONTH":
+        codes = sorted(set(user_period["codes"]))
+        future = [(y, m) for y, m in codes if _is_period_after((y, m), (ey, es), "MM")]
+        if future:
+            raise ValueError(
+                f"period 离散月 {future} 晚于最新有数据期 {latest_code}, 无可拉数据"
+            )
+        return [
+            f"{_fmt_nbs_code(y, m, 'MM')}-{_fmt_nbs_code(y, m, 'MM')}" for y, m in codes
+        ]
+
+    if pkind == "DISCRETE_QUARTER":
+        codes = sorted(set(user_period["codes"]))
+        future = [(y, q) for y, q in codes if _is_period_after((y, q), (ey, es), "SS")]
+        if future:
+            raise ValueError(
+                f"period 离散季 {future} 晚于最新有数据期 {latest_code}, 无可拉数据"
+            )
+        return [
+            f"{_fmt_nbs_code(y, q, 'SS')}-{_fmt_nbs_code(y, q, 'SS')}" for y, q in codes
+        ]
+
+    raise ValueError(f"未实现的 period kind: {pkind}")
 
 
-def _get_code_from_nbs_tree(tree: List[Dict], name: str, target: str = "id") -> str:
+def _validate_dts_within_slice(
+    dts: List[str],
+    leaf_slice: Optional[Tuple[Optional[int], Optional[int]]],
+    leaf_name_for_error: Optional[str] = None,
+) -> None:
+    """校验 dts 全部端点都落在 leaf 切片年份范围内. 不覆盖时 fail-fast.
+
+    PR1 不做跨切片 stitching, 否则会让 LAST_N 跨切片时静默返 NaN 列.
+    leaf_slice=None 表示 leaf 无切片标记 (单切片 catalog), 不做限制.
     """
-    根据指标名称从目录树中获取target编码
-    :param tree: 目录树
-    :param name: 指标名称
-    :param target: 指标编码属性名
-    :return: 指标编码
+    if leaf_slice is None:
+        return
+    slc_start, slc_end = leaf_slice
+    for span in dts:
+        if "-" not in span:
+            continue
+        a, b = span.split("-", 1)
+        sy, _, _ = _parse_nbs_code(a)
+        ey, _, _ = _parse_nbs_code(b)
+        if slc_start is not None and sy < slc_start:
+            raise ValueError(
+                f"period 起点年 {sy} 早于 leaf 切片起点 {slc_start}"
+                f"{' (' + leaf_name_for_error + ')' if leaf_name_for_error else ''}; "
+                f"PR1 不做跨切片拼接, 请在 path 末段切换到包含起点年的切片"
+            )
+        if slc_end is not None and ey > slc_end:
+            raise ValueError(
+                f"period 终点年 {ey} 晚于 leaf 切片终点 {slc_end}"
+                f"{' (' + leaf_name_for_error + ')' if leaf_name_for_error else ''}; "
+                f"PR1 不做跨切片拼接, 请切换到包含终点年的切片"
+            )
+
+
+def _expand_dts_to_codes(dts: List[str], suffix: str) -> List[str]:
+    """从 dts list 算出期望 period code 列表 (升序)."""
+    out = []
+    for span in dts:
+        if "-" not in span:
+            continue
+        a, b = span.split("-", 1)
+        sy, ss, _ = _parse_nbs_code(a)
+        ey, es, _ = _parse_nbs_code(b)
+        if suffix == "YY":
+            out.extend(f"{y}YY" for y in range(sy, ey + 1))
+        else:
+            units = 12 if suffix == "MM" else 4
+            si = sy * units + (ss - 1)
+            ei = ey * units + (es - 1)
+            for idx in range(si, ei + 1):
+                out.append(f"{idx // units:04d}{idx % units + 1:02d}{suffix}")
+    return out
+
+
+# ============ NBS Tree / Indicators / Da catalog (lazy lru_cache) ============
+
+
+@lru_cache(maxsize=2048)
+def _query_tree(pid: str, code: str) -> Tuple[Tuple[str, str, bool], ...]:
+    """获取 catalog 树某层节点. 返回 immutable tuple of (name, _id, isLeaf)."""
+    raw = _request_json(
+        "GET",
+        f"{NBS_BASE}/new/queryIndexTreeAsync",
+        params={"pid": pid, "code": code},
+    )
+    nodes = raw.get("data") or []
+    return tuple((n["_name"], n["_id"], n.get("isLeaf") is True) for n in nodes)
+
+
+@lru_cache(maxsize=512)
+def _query_indicators_cached(cid: str) -> Tuple[Tuple[Tuple[str, object], ...], ...]:
+    """指标元信息列表. 用 frozen tuple of items 做哈希."""
+    raw = _request_json(
+        "GET",
+        f"{NBS_BASE}/new/queryIndicatorsByCid",
+        params={"cid": cid, "dt": "", "name": ""},
+    )
+    data = raw.get("data") or {}
+    items = data.get("list") if isinstance(data, dict) else None
+    items = items or []
+    return tuple(tuple(it.items()) for it in items)
+
+
+def _query_indicators(cid: str) -> List[Dict[str, str]]:
+    return [dict(it) for it in _query_indicators_cached(cid)]
+
+
+@lru_cache(maxsize=256)
+def _resolve_da_catalog_cached(cid: str) -> Tuple[Tuple[str, str], ...]:
+    """拿地区列表 (name_text, name_value), fail-fast 当地区列表为空.
+
+    NBS 改版后某些 leaf 切片 (例 主要城市月度价格 (2026-)) 有 da_tree 但
+    getDasByDaCatalogId 返 0 个地区, 必须 fail-fast 不能继续 Mode A/B/C.
     """
-    expr = f'$[?(@.name == "{name}")].{target}'
-    ret = jp.jsonpath(tree, expr)
-    if ret is False:
-        raise ValueError("Please check if the data path or indicator is correct.")
-    return ret[0]
+    cats = (
+        _request_json(
+            "GET",
+            f"{NBS_BASE}/getDaCatalogTreeByIndicatorCid",
+            params={"indicatorCid": cid},
+        ).get("data")
+        or []
+    )
+    if not cats:
+        raise ValueError(f"catalog {cid} 无地区维度 (da_catalog 为空)")
+    da_cat_id = cats[0].get("_id") or cats[0].get("publicrelease_web_dacatalog_id")
+    raw = (
+        _request_json(
+            "GET",
+            f"{NBS_BASE}/getDasByDaCatalogId",
+            params={"daCid": da_cat_id},
+        ).get("data")
+        or []
+    )
+    if not raw:
+        raise ValueError(
+            f"catalog {cid} 地区列表为空, "
+            f"该 catalog 没有可枚举地区, 请改用更早期的时间切片或检查 NBS 是否未发布"
+        )
+    return tuple((d["name_text"], d["name_value"]) for d in raw)
+
+
+def _resolve_da_catalog(cid: str) -> List[Dict[str, str]]:
+    return [{"text": t, "value": v} for t, v in _resolve_da_catalog_cached(cid)]
+
+
+# ============ Path resolver ============
+
+
+def _select_leaf_by_period(
+    candidates: List[Tuple[str, str, bool]],
+    user_period: Dict[str, object],
+    path_for_error: str,
+) -> str:
+    """多 leaf 候选时按 period 选, 否则 fail-fast.
+
+    绝不"取最新候选" (用户传 (2021-2025) 但拿到 (2026-) 是静默错数据).
+    """
+    if len(candidates) == 1:
+        return candidates[0][1]
+
+    parsed = [(name, _id, _parse_slice_range(name)) for name, _id, _leaf in candidates]
+    pkind = user_period["kind"]
+
+    def _slice_contains(slc, year):
+        s, e = slc
+        if s is not None and year < s:
+            return False
+        if e is not None and year > e:
+            return False
+        return True
+
+    def _slice_covers_range(slc, start, end):
+        s, e = slc
+        if s is not None and start < s:
+            return False
+        if e is not None and end > e:
+            return False
+        return True
+
+    def _fail(reason: str):
+        raise ValueError(
+            f"path {path_for_error!r} {reason}. 请在 path 末段写出明确的时间切片. "
+            f"候选: " + " / ".join(n for n, _, _ in parsed)
+        )
+
+    if pkind == "LATEST":
+        open_right = [(n, i) for n, i, slc in parsed if slc and slc[1] is None]
+        if len(open_right) == 1:
+            return open_right[0][1]
+        _fail("多个候选切片, period 未指定具体范围无法唯一判断")
+
+    if pkind == "SINGLE":
+        year = int(user_period["year"])
+        hits = [(n, i) for n, i, slc in parsed if slc and _slice_contains(slc, year)]
+        if len(hits) == 1:
+            return hits[0][1]
+        _fail(f"单年 {year} 落在 {len(hits)} 个时间切片内")
+
+    if pkind == "RANGE":
+        s = int(user_period["start"])
+        e = int(user_period["end"])
+        hits = [
+            (n, i) for n, i, slc in parsed if slc and _slice_covers_range(slc, s, e)
+        ]
+        if len(hits) == 1:
+            return hits[0][1]
+        _fail(f"区间 {s}-{e} 跨多个或无完全覆盖切片")
+
+    if pkind == "OPEN_RANGE":
+        s = int(user_period["start"])
+        hits = [
+            (n, i)
+            for n, i, slc in parsed
+            if slc and slc[1] is None and (slc[0] is None or slc[0] <= s)
+        ]
+        if len(hits) == 1:
+            return hits[0][1]
+        _fail(f"开放区间 {s}- 跨多个或无适配切片")
+
+    if pkind in ("DISCRETE_YEAR", "DISCRETE_MONTH", "DISCRETE_QUARTER"):
+        years = []
+        for code in user_period["codes"]:
+            years.append(code if isinstance(code, int) else code[0])
+        ymin, ymax = min(years), max(years)
+        hits = [
+            (n, i)
+            for n, i, slc in parsed
+            if slc and _slice_covers_range(slc, ymin, ymax)
+        ]
+        if len(hits) == 1:
+            return hits[0][1]
+        _fail(f"离散值跨年范围 {ymin}-{ymax} 跨多个或无适配切片")
+
+    raise ValueError(f"未实现 leaf 选择: {pkind}")
+
+
+def _resolve_path(
+    kind: str, path: str, user_period: Dict[str, object]
+) -> Tuple[str, Optional[Tuple[Optional[int], Optional[int]]]]:
+    """path 字符串 → (leaf cid, leaf 切片 (start_year, end_year)).
+
+    切片为 None 表示 leaf name 没有时间区间标记 (例 `国内生产总值` 单切片 catalog).
+    含 leaf period-aware fallback.
+    """
+    if kind not in _KIND_TO_CODE:
+        raise ValueError(f"未知 kind: {kind!r}, 可选: {list(_KIND_TO_CODE.keys())}")
+    code = _KIND_TO_CODE[kind]
+    pid = _DATASETS[code]["root_id"]
+
+    parts_raw = [p.strip() for p in path.split(">") if p.strip()]
+    if not parts_raw:
+        raise ValueError(f"path 为空: {path!r}")
+    parts = [_normalize(p) for p in parts_raw]
+
+    chosen_leaf_name: Optional[str] = None
+    for i, part in enumerate(parts):
+        is_last = i == len(parts) - 1
+        nodes = _query_tree(pid, code)
+        if not nodes:
+            raise ValueError(
+                f"path 第 {i + 1} 段 {parts_raw[i]!r} 下无子节点 (parent_id={pid})"
+            )
+
+        # 1) 精确匹配 (双方 normalize)
+        exact = [(n, _id, leaf) for n, _id, leaf in nodes if _normalize(n) == part]
+        if exact:
+            if len(exact) > 1:
+                raise ValueError(
+                    f"path 第 {i + 1} 段 {parts_raw[i]!r} 精确匹配到多个同名节点: "
+                    f"{[(n, _id) for n, _id, _ in exact]}"
+                )
+            chosen_name, chosen_id, chosen_leaf = exact[0]
+            if is_last and not chosen_leaf:
+                next_layer = _query_tree(chosen_id, code)
+                raise ValueError(
+                    f"path 末段 {parts_raw[i]!r} 命中 catalog (非 leaf), "
+                    f"NBS 改版后该层级多了子层, 请加一段 path. "
+                    f"可选: {[n for n, _, _ in next_layer][:15]}"
+                )
+            pid = chosen_id
+            if is_last:
+                chosen_leaf_name = chosen_name
+            continue
+
+        if not is_last:
+            raise ValueError(
+                f"path 第 {i + 1} 段 {parts_raw[i]!r} 找不到 (parent_id={pid}); "
+                f"可选: {[n for n, _, _ in nodes][:10]}"
+            )
+
+        # 2) Leaf base-name fallback (仅 isLeaf=True 候选)
+        base = _strip_period_tail(part)
+        candidates = [
+            (n, _id, leaf)
+            for n, _id, leaf in nodes
+            if _strip_period_tail(_normalize(n)) == base and leaf
+        ]
+        if not candidates:
+            same_base_catalogs = [
+                n
+                for n, _, leaf in nodes
+                if _strip_period_tail(_normalize(n)) == base and not leaf
+            ]
+            if same_base_catalogs:
+                raise ValueError(
+                    f"path leaf {parts_raw[i]!r} 同 base name 仅匹配到 catalog 不是 leaf, "
+                    f"需要加一段 path. 匹配的 catalog: {same_base_catalogs}"
+                )
+            raise ValueError(
+                f"path leaf {parts_raw[i]!r} 找不到; "
+                f"可选: {[n for n, _, _ in nodes][:10]}"
+            )
+
+        pid = _select_leaf_by_period(candidates, user_period, path)
+        chosen_leaf_name = next(n for n, _id, _ in candidates if _id == pid)
+
+    leaf_slice = (
+        _parse_slice_range(_normalize(chosen_leaf_name)) if chosen_leaf_name else None
+    )
+    return pid, leaf_slice
+
+
+# ============ Indicator name → _id ============
+
+
+def _indicator_candidate_labels(meta: Dict[str, str]) -> List[str]:
+    """生成一个 indicator 的所有匹配候选 label, 用于多字段 normalize 比较."""
+    out = []
+    for k in ("i_showname", "_name", "ek_dp_name", "ek_name"):
+        v = meta.get(k)
+        if v:
+            out.append(v)
+    name = meta.get("_name", "")
+    dp = meta.get("dp_name", "")
+    du = meta.get("du_name", "")
+    kj1 = meta.get("kj1_name", "")
+    if name and du:
+        out.append(f"{name}({du})")
+        if dp:
+            out.append(f"{name}_{dp}({du})")
+    if name and kj1:
+        out.append(f"{name}({kj1})")
+        if dp and du:
+            out.append(f"{name}({kj1})_{dp}({du})")
+    return out
+
+
+def _match_indicator(user_indicator: str, metas: List[Dict[str, str]]) -> str:
+    """用户传的 indicator 名 → indicator _id. 二义性 fail-fast."""
+    if not user_indicator:
+        raise ValueError("indicator 名为空")
+    target = _normalize(user_indicator)
+    matched = []
+    for m in metas:
+        for cand in _indicator_candidate_labels(m):
+            if _normalize(cand) == target:
+                matched.append(m)
+                break
+    if not matched:
+        choices = [m.get("i_showname") or m.get("_name") for m in metas]
+        raise ValueError(
+            f"indicator {user_indicator!r} 在 catalog 下无匹配, 可选: {choices}"
+        )
+    if len(matched) > 1:
+        choices = [m.get("i_showname") or m.get("_name") for m in matched]
+        raise ValueError(
+            f"indicator {user_indicator!r} 匹配到多个候选 (normalize 二义性): {choices}"
+        )
+    return matched[0]["_id"]
+
+
+def _legacy_indicator_label(meta: Dict[str, str]) -> str:
+    """生成跟老版输出最接近的 row label.
+
+    新版 i_showname '地区生产总值累计值 (亿元) ', 老版输出 '地区生产总值_累计值(亿元)'.
+    我们去多余空格但**不强行加下划线** (NBS 字段无可靠还原).
+    """
+    showname = (meta.get("i_showname") or meta.get("_name") or "").strip()
+    return re.sub(r"\s+", "", showname)
+
+
+# ============ detect_latest_period ============
+
+
+@lru_cache(maxsize=512)
+def _detect_latest_cached(
+    cid: str, ids_key: Tuple[str, ...], root_id: str, das_key: str
+) -> Optional[str]:
+    """daCatalogId 永远 ""; 各 dataset 默认期数不同; 倒序找第一个 non-empty."""
+    payload = {
+        "cid": cid,
+        "indicatorIds": list(ids_key),
+        "daCatalogId": "",
+        "das": json.loads(das_key),
+        "showType": "1",
+        "dts": "",
+        "rootId": root_id,
+    }
+    raw = _request_json(
+        "POST",
+        f"{NBS_BASE}/getEsDataByCidAndDt",
+        json=payload,
+        headers={"Content-Type": "application/json;charset=UTF-8"},
+    )
+    rows = raw.get("data") or []
+    # 显式按 code 倒序排 (NBS 默认顺序未保证)
+    try:
+        rows = sorted(rows, key=lambda r: r.get("code") or "", reverse=True)
+    except TypeError:
+        pass
+    for row in rows:
+        for v in row.get("values") or []:
+            if v.get("value") not in ("", None):
+                return row.get("code")
+    return None
+
+
+def _detect_latest_period(
+    cid: str, ids: List[str], root_id: str, das: Optional[List[Dict[str, str]]] = None
+) -> Optional[str]:
+    if das is None:
+        das = [{"text": "全国", "value": "000000000000"}]
+    return _detect_latest_cached(
+        cid,
+        tuple(sorted(ids)),
+        root_id,
+        json.dumps(das, sort_keys=True, ensure_ascii=False),
+    )
+
+
+# ============ Fetch data (daCatalogId="") ============
+
+
+def _fetch_data(
+    cid: str, ids: List[str], root_id: str, das: List[Dict[str, str]], dts: List[str]
+) -> List[dict]:
+    """所有 fetch 一律 daCatalogId="" (否则 NBS 忽略 das 走默认地区)."""
+    payload = {
+        "cid": cid,
+        "indicatorIds": ids,
+        "daCatalogId": "",
+        "das": das,
+        "showType": "1",
+        "dts": dts,
+        "rootId": root_id,
+    }
+    raw = _request_json(
+        "POST",
+        f"{NBS_BASE}/getEsDataByCidAndDt",
+        json=payload,
+        headers={"Content-Type": "application/json;charset=UTF-8"},
+    )
+    return raw.get("data") or []
+
+
+def _row_first_value(row: dict) -> Optional[str]:
+    """row.values[0].value, 防 IndexError."""
+    vals = row.get("values") or []
+    if not vals:
+        return None
+    return vals[0].get("value")
+
+
+# ============ 公开函数 ============
 
 
 def macro_china_nbs_nation(
-    kind: Literal["月度数据", "季度数据", "年度数据"], path: str, period: str = "LAST10"
+    kind: Literal["月度数据", "季度数据", "年度数据"],
+    path: str,
+    period: str = "LAST10",
 ) -> pd.DataFrame:
     """
     国家统计局全国数据通用接口
-    https://data.stats.gov.cn/easyquery.htm
-    :param kind: 数据类别
-    :param path: 数据路径
-    :param period: 时间区间，例如'LAST10', '2016-2023', '2016-'等
+    https://data.stats.gov.cn/dg/website/
+
+    NBS 2026 改版后老 easyquery.htm 端点失效, 本接口直连新版 GUID API.
+    对外签名与旧版兼容; path 解析支持 leaf 节点的多时间切片 fallback.
+
+    :param kind: 数据类别, 月度/季度/年度
+    :param path: 数据路径, 多层级用 ' > ' 连接, 例如 '价格指数 > 居民消费价格指数(上年同月=100)'
+        NBS 改版后某些 catalog 多了一层 (例 CPI 多了"全国/城市/农村"维度);
+        路径不到 leaf 时函数会 fail-fast 列出可选子项.
+    :param period: 时间区间, 支持以下格式:
+        - 'last10' / 'LAST10' (大小写均可)
+        - 月度逗号离散: '201201,201205'
+        - 季度逗号离散: '2012A,2012B,2012C,2012D' (A-D 表 Q1-Q4)
+        - 年度逗号离散: '2012,2013'
+        - 区间: '2018-2023'
+        - 至今: '2013-'
+        - 单年: '2018'
     :return: 国家统计局统计数据
     :rtype: pandas.DataFrame
     """
-    # 获取dbcode
-    kind_code = {"月度数据": "hgyd", "季度数据": "hgjd", "年度数据": "hgnd"}
-    dbcode = kind_code[kind]
+    if kind not in {"月度数据", "季度数据", "年度数据"}:
+        raise ValueError(f"nation 接口 kind 必须是月度/季度/年度, 得到 {kind!r}")
+    user_period = _parse_user_period(period)
+    cid, leaf_slice = _resolve_path(kind, path, user_period)
 
-    # 获取最终id
-    parent_tree = _get_nbs_tree("zb", dbcode)
-    path_split = path.replace(" ", "").split(">")
-    indicator_id = _get_code_from_nbs_tree(parent_tree, path_split[0])
-    path_split.pop(0)
-    while path_split:
-        temp_tree = _get_nbs_tree(indicator_id, dbcode)
-        indicator_id = _get_code_from_nbs_tree(temp_tree, path_split[0])
-        path_split.pop(0)
+    metas = _query_indicators(cid)
+    if not metas:
+        raise ValueError(f"catalog {cid} 无 indicators (path 可能未到 leaf)")
+    ind_ids = [m["_id"] for m in metas]
 
-    # 请求数据
-    url = "https://data.stats.gov.cn/easyquery.htm"
-    params = {
-        "m": "QueryData",
-        "dbcode": dbcode,
-        "rowcode": "zb",
-        "colcode": "sj",
-        "wds": "[]",
-        "dfwds": '[{"wdcode":"zb","valuecode":"%s"}, '
-        '{"wdcode":"sj","valuecode":"%s"}]' % (indicator_id, period),
-        "k1": str(time.time_ns())[:13],
+    code = _KIND_TO_CODE[kind]
+    root_id = _DATASETS[code]["root_id"]
+    suffix = _KIND_TO_SUFFIX[kind]
+
+    latest = _detect_latest_period(cid, ind_ids, root_id)
+    if latest is None:
+        raise ValueError("探测最新有数据期失败 (catalog 可能无数据)")
+    dts = _period_to_dts(kind, user_period, latest)
+    _validate_dts_within_slice(dts, leaf_slice)
+    expected_codes = _expand_dts_to_codes(dts, suffix)
+
+    rows = _fetch_data(
+        cid,
+        ind_ids,
+        root_id,
+        das=[{"text": "全国", "value": "000000000000"}],
+        dts=dts,
+    )
+    code_to_name = {
+        r["code"]: r["name"] for r in rows if r.get("code") and r.get("name")
     }
-    r = requests.get(url, params=params, verify=False, allow_redirects=True)
-    data_json = r.json()
 
-    # 整理为dataframe
-    temp_df = pd.DataFrame(data_json["returndata"]["datanodes"])
-    temp_df["data"] = temp_df["data"].apply(
-        lambda x: x["data"] if x["hasdata"] else None
-    )
+    row_labels = [_legacy_indicator_label(m) for m in metas]
+    ind_id_to_label = {m["_id"]: _legacy_indicator_label(m) for m in metas}
 
-    wdnodes = data_json["returndata"]["wdnodes"]
-    wn_df_list = []
-    for wn in wdnodes:
-        wn_df_list.append(
-            pd.DataFrame(wn["nodes"])
-            .assign(
-                funit=lambda df: df["unit"].apply(lambda x: "(" + x + ")" if x else x)
-            )
-            .assign(fname=lambda df: df["cname"] + df["funit"]),
-        )
+    # 列降序 (老版示例最新在前)
+    col_codes = sorted(expected_codes, reverse=True)
+    col_labels = [code_to_name.get(c, c) for c in col_codes]
 
-    row_name, column_name = (
-        wn_df_list[0]["fname"],
-        wn_df_list[1]["fname"],
-    )
+    data: Dict[str, Dict[str, object]] = {label: {} for label in row_labels}
+    for row in rows:
+        col = code_to_name.get(row.get("code"), row.get("code"))
+        for v in row.get("values") or []:
+            ind_id = v.get("_id")
+            if ind_id in ind_id_to_label:
+                val = v.get("value")
+                data[ind_id_to_label[ind_id]][col] = (
+                    val if val not in ("", None) else None
+                )
 
-    data_ndarray = np.reshape(temp_df["data"], (len(row_name), len(column_name)))
-    data_df = pd.DataFrame(data=data_ndarray, columns=column_name, index=row_name)
-    data_df.index.name = None
-    data_df.columns.name = None
-
-    return data_df
+    df = pd.DataFrame(
+        [[data[r].get(c) for c in col_labels] for r in row_labels],
+        index=row_labels,
+        columns=col_labels,
+    ).apply(pd.to_numeric, errors="coerce")
+    df.index.name = None
+    df.columns.name = None
+    return df
 
 
 def macro_china_nbs_region(
@@ -157,137 +924,176 @@ def macro_china_nbs_region(
         "港澳台年度数据",
     ],
     path: str,
-    indicator: Union[str, None],
+    indicator: Union[str, None] = None,
     region: Union[str, None] = None,
     period: str = "LAST10",
 ) -> pd.DataFrame:
     """
     国家统计局地区数据通用接口
-    https://data.stats.gov.cn/easyquery.htm
-    :param kind: 数据类别
+    https://data.stats.gov.cn/dg/website/
+
+    支持三种模式:
+    - region=None + indicator: 行=地区, 列=时期 (循环各地区串行 fetch)
+    - region + indicator=None: 行=指标, 列=时期 (该地区下所有指标)
+    - region + indicator: 行=单指标, 列=时期
+
+    :param kind: 数据类别 (分省/主要城市/港澳台 × 月/季/年)
     :param path: 数据路径
-    :param indicator: 指定指标
-    :param region:  指定地区 当指定region时，将symbol设为None可以同时获得所有可选指标的值
-    :param period: 时间区间，例如'LAST10', '2016-2023', '2016-'等
-    :return: 国家统计局统计数据
+    :param indicator: 指定指标 (region 给定时可为 None 拿全部)
+    :param region: 指定地区 (indicator 给定时可为 None 拿所有地区)
+    :param period: 时间区间, 格式同 nation 接口
+    :return: 国家统计局地区数据
     :rtype: pandas.DataFrame
     """
     if indicator is None and region is None:
-        raise AssertionError("The indicator and region parameters cannot both be None.")
-
-    # 获取dbcode
-    kind_dict = {
-        "分省月度数据": "fsyd",
-        "分省季度数据": "fsjd",
-        "分省年度数据": "fsnd",
-        "主要城市月度价格": "csyd",
-        "主要城市年度数据": "csnd",
-        "港澳台月度数据": "gatyd",
-        "港澳台年度数据": "gatnd",
+        raise ValueError("indicator 和 region 不能同时为 None")
+    valid_kinds = {
+        "分省月度数据",
+        "分省季度数据",
+        "分省年度数据",
+        "主要城市月度价格",
+        "主要城市年度数据",
+        "港澳台月度数据",
+        "港澳台年度数据",
     }
-    dbcode = kind_dict[kind]
+    if kind not in valid_kinds:
+        raise ValueError(f"region 接口 kind 不在 {valid_kinds}, 得到 {kind!r}")
 
-    # 获取最终id
-    parent_tree = _get_nbs_tree("zb", dbcode)
-    path_split = path.replace(" ", "").split(">")
-    indicator_id = _get_code_from_nbs_tree(parent_tree, path_split[0])
-    path_split.pop(0)
-    while path_split:
-        temp_tree = _get_nbs_tree(indicator_id, dbcode)
-        indicator_id = _get_code_from_nbs_tree(temp_tree, path_split[0])
-        path_split.pop(0)
+    user_period = _parse_user_period(period)
+    cid, leaf_slice = _resolve_path(kind, path, user_period)
 
-    # 参数设定
+    metas = _query_indicators(cid)
+    if not metas:
+        raise ValueError(f"catalog {cid} 无 indicators (path 可能未到 leaf)")
+    das_list = _resolve_da_catalog(cid)  # 空地区在此 fail-fast
+
+    code = _KIND_TO_CODE[kind]
+    root_id = _DATASETS[code]["root_id"]
+    suffix = _KIND_TO_SUFFIX[kind]
+
+    # ===== Mode A: region=None + indicator =====
     if region is None:
-        indicator_tree = _get_nbs_wds_tree(indicator_id, dbcode, "reg")
-        indicator_id = _get_code_from_nbs_tree(indicator_tree, indicator, target="code")
-        rowcode = "reg"
-        colcode = "sj"
-        wds = '[{"wdcode":"zb","valuecode":"%s"}]' % indicator_id
-        dfwds = '[{"wdcode":"sj","valuecode":"%s"}]' % period
-    else:
-        if indicator is not None:
-            indicator_tree = _get_nbs_wds_tree(indicator_id, dbcode, "reg")
-            indicator_id = _get_code_from_nbs_tree(
-                indicator_tree, indicator, target="code"
-            )
-        region_tree = _get_nbs_wds_tree(indicator_id, dbcode, "zb")
-        region_id = _get_code_from_nbs_tree(region_tree, region, target="code")
-        rowcode = "zb"
-        colcode = "sj"
-        wds = '[{"wdcode":"reg","valuecode":"%s"}]' % region_id
-        dfwds = (
-            '[{"wdcode":"zb","valuecode":"%s"}, '
-            '{"wdcode":"sj","valuecode":"%s"}]' % (indicator_id, period)
+        ind_id = _match_indicator(indicator, metas)
+        ind_meta = next(m for m in metas if m["_id"] == ind_id)
+        ind_label = _legacy_indicator_label(ind_meta)
+
+        latest = _detect_latest_period(cid, [ind_id], root_id, das=[das_list[0]])
+        if latest is None:
+            raise ValueError("探测最新期失败")
+        dts = _period_to_dts(kind, user_period, latest)
+        _validate_dts_within_slice(dts, leaf_slice)
+        expected = _expand_dts_to_codes(dts, suffix)
+
+        # 循环各地区串行 fetch (das 多地区不工作, 只能逐个调)
+        per_region: Dict[str, Dict[str, object]] = {}
+        col_name_map: Dict[str, str] = {}
+        for da in das_list:
+            rows = _fetch_data(cid, [ind_id], root_id, das=[da], dts=dts)
+            for r in rows:
+                if r.get("code") and r.get("name"):
+                    col_name_map[r["code"]] = r["name"]
+            per_region[da["text"]] = {
+                r["code"]: (
+                    _row_first_value(r)
+                    if _row_first_value(r) not in ("", None)
+                    else None
+                )
+                for r in rows
+                if r.get("code")
+            }
+
+        col_codes = sorted(expected, reverse=True)
+        col_labels = [col_name_map.get(c, c) for c in col_codes]
+        row_labels = [d["text"] for d in das_list]
+
+        df = pd.DataFrame(
+            [[per_region[r].get(c) for c in col_codes] for r in row_labels],
+            index=row_labels,
+            columns=col_labels,
+        ).apply(pd.to_numeric, errors="coerce")
+        df = df.dropna(axis=1, how="all")
+        df.index.name = None
+        df.columns.name = ind_label
+        return df
+
+    # ===== Mode B/C: region != None =====
+    target_das = [d for d in das_list if d["text"] == region]
+    if not target_das:
+        raise ValueError(
+            f"region {region!r} 不在 das_list 中, "
+            f"可选: {[d['text'] for d in das_list][:10]}..."
         )
 
-    # 请求数据
-    url = "https://data.stats.gov.cn/easyquery.htm"
-    params = {
-        "m": "QueryData",
-        "dbcode": dbcode,
-        "rowcode": rowcode,
-        "colcode": colcode,
-        "wds": wds,
-        "dfwds": dfwds,
-        "k1": str(time.time_ns())[:13],
-    }
-    r = requests.get(url, params=params, verify=False, allow_redirects=True)
-    data_json = r.json()
-
-    # 整理为dataframe
-    temp_df = pd.DataFrame(data_json["returndata"]["datanodes"])
-    temp_df["data"] = temp_df["data"].apply(
-        lambda x: x["data"] if x["hasdata"] else None
-    )
-
-    wdnodes = data_json["returndata"]["wdnodes"]
-    wn_df_list = []
-    for wn in wdnodes:
-        wn_df_list.append(
-            pd.DataFrame(wn["nodes"])
-            .assign(
-                funit=lambda df: df["unit"].apply(lambda x: "(" + x + ")" if x else x)
-            )
-            .assign(fname=lambda df: df["cname"] + df["funit"]),
-        )
-
-    if region is None:
-        row_name, column_name = wn_df_list[1]["fname"], wn_df_list[2]["fname"]
-        title_name = wn_df_list[0]["fname"][0]
+    if indicator is None:
+        # Mode B: 单地区 + 全部 indicator (单请求多 indicatorIds)
+        ind_ids = [m["_id"] for m in metas]
+        ind_labels = [_legacy_indicator_label(m) for m in metas]
+        ind_id_to_label = {m["_id"]: _legacy_indicator_label(m) for m in metas}
+        latest = _detect_latest_period(cid, ind_ids, root_id, das=target_das)
     else:
-        row_name, column_name = wn_df_list[0]["fname"], wn_df_list[2]["fname"]
-        title_name = wn_df_list[1]["fname"][0]
+        # Mode C: 单地区 + 单 indicator
+        ind_id = _match_indicator(indicator, metas)
+        ind_ids = [ind_id]
+        ind_meta = next(m for m in metas if m["_id"] == ind_id)
+        ind_labels = [_legacy_indicator_label(ind_meta)]
+        ind_id_to_label = {ind_id: ind_labels[0]}
+        latest = _detect_latest_period(cid, ind_ids, root_id, das=target_das)
 
-    data_ndarray = np.reshape(temp_df["data"], (len(row_name), len(column_name)))
-    data_df = pd.DataFrame(data=data_ndarray, columns=column_name, index=row_name)
-    data_df.index.name = None
-    data_df.columns.name = title_name
+    if latest is None:
+        raise ValueError(f"region={region} 探测最新期失败")
+    dts = _period_to_dts(kind, user_period, latest)
+    _validate_dts_within_slice(dts, leaf_slice)
+    expected = _expand_dts_to_codes(dts, suffix)
 
-    return data_df
+    rows = _fetch_data(cid, ind_ids, root_id, das=target_das, dts=dts)
+    code_to_name = {
+        r["code"]: r["name"] for r in rows if r.get("code") and r.get("name")
+    }
+
+    data: Dict[str, Dict[str, object]] = {label: {} for label in ind_labels}
+    for row in rows:
+        for v in row.get("values") or []:
+            ind_id_v = v.get("_id")
+            if ind_id_v in ind_id_to_label:
+                val = v.get("value")
+                data[ind_id_to_label[ind_id_v]][row["code"]] = (
+                    val if val not in ("", None) else None
+                )
+
+    col_codes = sorted(expected, reverse=True)
+    col_labels = [code_to_name.get(c, c) for c in col_codes]
+
+    df = pd.DataFrame(
+        [[data[r].get(c) for c in col_codes] for r in ind_labels],
+        index=ind_labels,
+        columns=col_labels,
+    ).apply(pd.to_numeric, errors="coerce")
+    df.index.name = None
+    df.columns.name = region
+    return df
 
 
 if __name__ == "__main__":
     macro_china_nbs_nation_df = macro_china_nbs_nation(
-        kind="月度数据",
-        path="工业 > 工业分大类行业出口交货值(2018-至今) > 废弃资源综合利用业",
+        kind="年度数据",
+        path="国民经济核算 > 国内生产总值",
         period="LAST5",
     )
     print(macro_china_nbs_nation_df)
 
     macro_china_nbs_region_df = macro_china_nbs_region(
         kind="分省季度数据",
-        path="人民生活 > 居民人均可支配收入",
-        period="2018-2022",
-        indicator=None,
-        region="北京市",
+        path="国民经济核算 > 地区生产总值",
+        indicator="地区生产总值累计值(亿元)",
+        period="LAST3",
     )
     print(macro_china_nbs_region_df)
 
     macro_china_nbs_region_df = macro_china_nbs_region(
         kind="分省季度数据",
         path="国民经济核算 > 地区生产总值",
-        period="2018-",
-        indicator="地区生产总值_累计值(亿元)",
+        period="last3",
+        indicator=None,
+        region="河北省",
     )
     print(macro_china_nbs_region_df)

--- a/docs/data/macro/macro.md
+++ b/docs/data/macro/macro.md
@@ -4637,11 +4637,17 @@ print(macro_china_au_report_df)
 
 #### 国家统计局通用接口
 
+> **注意 (2026-03 改版)**: NBS 已切到新版数据发布库 (`https://data.stats.gov.cn/dg/website/`), 本节两个接口已对接新版 API. 几个行为变化:
+>
+> - NBS 改版后某些 catalog 多了一层 (例 CPI 多了"全国/城市/农村 × 时间切片"), 需要把 path 写到 leaf 一级; 命中 catalog 时函数会 fail-fast 列出可选 leaf
+> - 跨 NBS 时间切片不自动拼接; period 跨切片时函数会 fail-fast 提示切换到合适切片
+> - 新版返回的 indicator label 可能不含旧版下划线 (例 `地区生产总值累计值(亿元)` 而非 `地区生产总值_累计值(亿元)`); 输入侧用旧 label 仍能匹配 (内部 normalize 处理)
+
 ##### 国家统计局全国数据
 
 接口: macro_china_nbs_nation
 
-目标地址: https://data.stats.gov.cn/easyquery.htm
+目标地址: https://data.stats.gov.cn/dg/website/
 
 描述: 国家统计局全国数据通用接口，包括月度数据、季度数据、年度数据，具体指标见数据官网。
 
@@ -4685,7 +4691,7 @@ print(macro_china_nbs_nation_df)
 
 接口: macro_china_nbs_region
 
-目标地址: https://data.stats.gov.cn/easyquery.htm
+目标地址: https://data.stats.gov.cn/dg/website/
 
 描述: 国家统计局地区数据通用接口，包括分省月度数据、分省季度数据、分省年度数据、主要城市月度价格、主要城市年度数据、港澳台月度数据、港澳台年度数据，具体指标见数据官网。
 

--- a/tests/test_macro_china_nbs.py
+++ b/tests/test_macro_china_nbs.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+"""
+Date: 2026/5/8 10:00
+Desc: 国家统计局 NBS 接口测试 (issues #7180 #7211 #7216 修复后)
+
+纯单元测试默认运行; 联网 smoke 默认 skip, 设环境变量 AKSHARE_NETWORK_TESTS=1 启用.
+"""
+
+import os
+
+import pandas as pd
+import pytest
+
+from akshare.economic.macro_china_nbs import (
+    _parse_user_period,
+    _normalize,
+    _strip_period_tail,
+    _parse_slice_range,
+    _parse_nbs_code,
+    _shift_period,
+    _fmt_nbs_code,
+    _period_to_dts,
+    _expand_dts_to_codes,
+    _validate_dts_within_slice,
+    macro_china_nbs_nation,
+    macro_china_nbs_region,
+)
+
+_RUN_NETWORK = os.environ.get("AKSHARE_NETWORK_TESTS") == "1"
+
+
+# ============ 纯单元测试 (不联网) ============
+
+
+class TestNormalize:
+    def test_basic_strip(self):
+        assert _normalize("foo bar") == "foobar"
+        assert _normalize("foo　bar") == "foobar"  # 全角空格
+
+    def test_full_width_punctuation(self):
+        assert _normalize("foo（bar）") == "foo(bar)"
+        assert _normalize("foo：bar") == "foo:bar"
+
+    def test_underscore_removed(self):
+        assert _normalize("a_b_c") == "abc"
+
+    def test_nbs_real_name(self):
+        # NBS 改版后 catalog name 加了空格
+        nbs = "居民消费价格分类指数 (上年同月=100) "
+        user = "居民消费价格分类指数(上年同月=100)"
+        assert _normalize(nbs) == _normalize(user)
+
+    def test_underscore_label(self):
+        # 老版用户传带下划线
+        old = "地区生产总值_累计值(亿元)"
+        new = "地区生产总值累计值 (亿元) "
+        assert _normalize(old) == _normalize(new)
+
+    def test_empty_and_none(self):
+        assert _normalize(None) == ""
+        assert _normalize("") == ""
+
+
+class TestStripPeriodTail:
+    def test_strip_basic(self):
+        assert _strip_period_tail("xxx(2018-2025)") == "xxx"
+        assert _strip_period_tail("xxx(2026-)") == "xxx"
+        assert _strip_period_tail("xxx(-2015)") == "xxx"
+        assert _strip_period_tail("xxx(2018-至今)") == "xxx"
+
+    def test_no_tail(self):
+        assert _strip_period_tail("xxx") == "xxx"
+
+
+class TestParseSliceRange:
+    def test_closed(self):
+        assert _parse_slice_range("xxx(2018-2025)") == (2018, 2025)
+
+    def test_open_right(self):
+        assert _parse_slice_range("xxx(2026-)") == (2026, None)
+        assert _parse_slice_range("xxx(2018-至今)") == (2018, None)
+
+    def test_open_left(self):
+        assert _parse_slice_range("xxx(-2015)") == (None, 2015)
+
+    def test_no_tail(self):
+        assert _parse_slice_range("xxx") is None
+
+
+class TestParseUserPeriod:
+    def test_last_lower_and_upper(self):
+        assert _parse_user_period("last10") == {"kind": "LATEST", "n": 10}
+        assert _parse_user_period("LAST10") == {"kind": "LATEST", "n": 10}
+        assert _parse_user_period("LaSt5") == {"kind": "LATEST", "n": 5}
+
+    def test_none_and_empty(self):
+        assert _parse_user_period(None)["kind"] == "LATEST"
+        assert _parse_user_period("")["kind"] == "LATEST"
+        assert _parse_user_period("  ")["kind"] == "LATEST"
+
+    def test_range(self):
+        assert _parse_user_period("2018-2023") == {
+            "kind": "RANGE",
+            "start": 2018,
+            "end": 2023,
+        }
+
+    def test_open_range(self):
+        assert _parse_user_period("2018-") == {"kind": "OPEN_RANGE", "start": 2018}
+
+    def test_single_year(self):
+        assert _parse_user_period("2022") == {"kind": "SINGLE", "year": 2022}
+
+    def test_discrete_month(self):
+        r = _parse_user_period("201201,201205")
+        assert r["kind"] == "DISCRETE_MONTH"
+        assert r["codes"] == [(2012, 1), (2012, 5)]
+
+    def test_discrete_quarter(self):
+        r = _parse_user_period("2012A,2012B,2012C,2012D")
+        assert r["kind"] == "DISCRETE_QUARTER"
+        assert r["codes"] == [(2012, 1), (2012, 2), (2012, 3), (2012, 4)]
+
+    def test_discrete_year(self):
+        r = _parse_user_period("2012,2013")
+        assert r["kind"] == "DISCRETE_YEAR"
+        assert r["codes"] == [2012, 2013]
+
+    def test_invalid(self):
+        with pytest.raises(ValueError):
+            _parse_user_period("abc")
+        with pytest.raises(ValueError):
+            _parse_user_period("2012,201205")  # 类型不一致
+
+    def test_last_zero_rejected(self):
+        with pytest.raises(ValueError):
+            _parse_user_period("last0")
+
+    def test_discrete_month_invalid_month_fails(self):
+        # 月份必须 1-12, '201213' 这种应 fail-fast
+        with pytest.raises(ValueError, match="非法月份"):
+            _parse_user_period("201213,201214")
+
+
+class TestNbsCode:
+    def test_parse(self):
+        assert _parse_nbs_code("202604MM") == (2026, 4, "MM")
+        assert _parse_nbs_code("202404SS") == (2024, 4, "SS")
+        assert _parse_nbs_code("2025YY") == (2025, 0, "YY")
+
+    def test_fmt(self):
+        assert _fmt_nbs_code(2026, 4, "MM") == "202604MM"
+        assert _fmt_nbs_code(2024, 4, "SS") == "202404SS"
+        assert _fmt_nbs_code(2025, 0, "YY") == "2025YY"
+
+    def test_shift(self):
+        assert _shift_period(2026, 4, "MM", 1) == (2026, 3)
+        assert _shift_period(2026, 1, "MM", 1) == (2025, 12)  # 跨年
+        assert _shift_period(2026, 1, "SS", 1) == (2025, 4)
+        assert _shift_period(2025, 0, "YY", 5) == (2020, 0)
+
+
+class TestPeriodToDts:
+    def test_last_n_month(self):
+        # latest = 202604MM, LAST5 应该是 202512MM-202604MM
+        dts = _period_to_dts("月度数据", {"kind": "LATEST", "n": 5}, "202604MM")
+        assert dts == ["202512MM-202604MM"]
+
+    def test_last_n_quarter(self):
+        # latest = 202601SS, LAST5 应该是 202501SS-202601SS (5 个季度)
+        dts = _period_to_dts("季度数据", {"kind": "LATEST", "n": 5}, "202601SS")
+        assert dts == ["202501SS-202601SS"]
+
+    def test_last_n_year(self):
+        dts = _period_to_dts("年度数据", {"kind": "LATEST", "n": 5}, "2025YY")
+        assert dts == ["2021YY-2025YY"]
+
+    def test_range_year(self):
+        dts = _period_to_dts(
+            "年度数据", {"kind": "RANGE", "start": 2018, "end": 2023}, "2025YY"
+        )
+        assert dts == ["2018YY-2023YY"]
+
+    def test_range_month(self):
+        dts = _period_to_dts(
+            "月度数据", {"kind": "RANGE", "start": 2020, "end": 2022}, "202604MM"
+        )
+        assert dts == ["202001MM-202212MM"]
+
+    def test_range_quarter(self):
+        dts = _period_to_dts(
+            "季度数据", {"kind": "RANGE", "start": 2020, "end": 2022}, "202601SS"
+        )
+        assert dts == ["202001SS-202204SS"]
+
+    def test_range_clamp_end(self):
+        # end 2030 超过 latest 2025, 应 clamp 到 latest
+        dts = _period_to_dts(
+            "年度数据", {"kind": "RANGE", "start": 2020, "end": 2030}, "2025YY"
+        )
+        assert dts == ["2020YY-2025YY"]
+
+    def test_range_start_after_latest_fails(self):
+        # start 2026 晚于 latest 2025, 应 fail-fast
+        with pytest.raises(ValueError):
+            _period_to_dts(
+                "年度数据", {"kind": "RANGE", "start": 2026, "end": 2030}, "2025YY"
+            )
+
+    def test_range_start_after_end_fails(self):
+        with pytest.raises(ValueError):
+            _period_to_dts(
+                "年度数据", {"kind": "RANGE", "start": 2025, "end": 2018}, "2025YY"
+            )
+
+    def test_single_year_clamp_current_year(self):
+        # period="2026" + latest 202604MM, 单年 2026 终点应 clamp 到 4 月不是 12 月
+        dts = _period_to_dts("月度数据", {"kind": "SINGLE", "year": 2026}, "202604MM")
+        assert dts == ["202601MM-202604MM"]
+
+    def test_single_year_future_fails(self):
+        # period="2030" + latest 2025YY, 应 fail-fast
+        with pytest.raises(ValueError):
+            _period_to_dts("年度数据", {"kind": "SINGLE", "year": 2030}, "2025YY")
+
+    def test_discrete_year_future_fails(self):
+        with pytest.raises(ValueError):
+            _period_to_dts(
+                "年度数据",
+                {"kind": "DISCRETE_YEAR", "codes": [2024, 2030]},
+                "2025YY",
+            )
+
+    def test_discrete_month_future_fails(self):
+        with pytest.raises(ValueError):
+            _period_to_dts(
+                "月度数据",
+                {"kind": "DISCRETE_MONTH", "codes": [(2026, 12), (2027, 1)]},
+                "202604MM",
+            )
+
+    def test_discrete_kind_mismatch_fails(self):
+        # 月度 kind 用年度逗号 → fail-fast
+        with pytest.raises(ValueError, match="不匹配"):
+            _period_to_dts(
+                "月度数据",
+                {"kind": "DISCRETE_YEAR", "codes": [2012, 2013]},
+                "202604MM",
+            )
+        # 年度 kind 用月度逗号 → fail-fast
+        with pytest.raises(ValueError, match="不匹配"):
+            _period_to_dts(
+                "年度数据",
+                {"kind": "DISCRETE_MONTH", "codes": [(2012, 1)]},
+                "2025YY",
+            )
+
+    def test_open_range(self):
+        dts = _period_to_dts(
+            "年度数据", {"kind": "OPEN_RANGE", "start": 2018}, "2025YY"
+        )
+        assert dts == ["2018YY-2025YY"]
+
+    def test_single_year(self):
+        dts = _period_to_dts("月度数据", {"kind": "SINGLE", "year": 2022}, "202604MM")
+        assert dts == ["202201MM-202212MM"]
+
+    def test_discrete_month(self):
+        dts = _period_to_dts(
+            "月度数据",
+            {"kind": "DISCRETE_MONTH", "codes": [(2012, 1), (2012, 5)]},
+            "202604MM",
+        )
+        assert dts == ["201201MM-201201MM", "201205MM-201205MM"]
+
+    def test_discrete_quarter(self):
+        dts = _period_to_dts(
+            "季度数据",
+            {"kind": "DISCRETE_QUARTER", "codes": [(2012, 1), (2012, 4)]},
+            "202601SS",
+        )
+        assert dts == ["201201SS-201201SS", "201204SS-201204SS"]
+
+
+class TestValidateDtsWithinSlice:
+    """跨切片 fail-fast — PR1 不做跨切片 stitching."""
+
+    def test_no_slice_passes(self):
+        # leaf 无切片标记, 不限制
+        _validate_dts_within_slice(["2018YY-2025YY"], None)
+
+    def test_within_closed_slice(self):
+        _validate_dts_within_slice(["2022YY-2024YY"], (2021, 2025))
+
+    def test_below_start_fails(self):
+        with pytest.raises(ValueError, match="早于"):
+            _validate_dts_within_slice(["2018YY-2024YY"], (2021, 2025))
+
+    def test_above_end_fails(self):
+        with pytest.raises(ValueError, match="晚于"):
+            _validate_dts_within_slice(["2022YY-2026YY"], (2021, 2025))
+
+    def test_open_right_slice(self):
+        _validate_dts_within_slice(["2027YY-2030YY"], (2026, None))
+        with pytest.raises(ValueError, match="早于"):
+            _validate_dts_within_slice(["2025YY-2027YY"], (2026, None))
+
+    def test_open_left_slice(self):
+        _validate_dts_within_slice(["2010YY-2015YY"], (None, 2015))
+        with pytest.raises(ValueError, match="晚于"):
+            _validate_dts_within_slice(["2010YY-2016YY"], (None, 2015))
+
+
+class TestExpandDtsToCodes:
+    def test_year(self):
+        assert _expand_dts_to_codes(["2018YY-2020YY"], "YY") == [
+            "2018YY",
+            "2019YY",
+            "2020YY",
+        ]
+
+    def test_month(self):
+        codes = _expand_dts_to_codes(["202401MM-202403MM"], "MM")
+        assert codes == ["202401MM", "202402MM", "202403MM"]
+
+    def test_quarter(self):
+        codes = _expand_dts_to_codes(["202301SS-202304SS"], "SS")
+        assert codes == ["202301SS", "202302SS", "202303SS", "202304SS"]
+
+    def test_multi_span(self):
+        codes = _expand_dts_to_codes(["2018YY-2018YY", "2020YY-2020YY"], "YY")
+        assert codes == ["2018YY", "2020YY"]
+
+
+# ============ 联网 smoke (走 NBS HTTP, 数据可能变) ============
+
+
+@pytest.mark.skipif(
+    not _RUN_NETWORK,
+    reason="联网 smoke 默认跳过, 设 AKSHARE_NETWORK_TESTS=1 启用",
+)
+class TestNbsSmokeNetwork:
+    """NBS 联网测试. 验证基本 shape/dtype/schema, 不测固定值 (NBS 数据会更新)."""
+
+    def test_nation_yearly_gdp(self):
+        df = macro_china_nbs_nation(
+            kind="年度数据",
+            path="国民经济核算 > 国内生产总值",
+            period="LAST5",
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert df.shape[0] >= 3  # GDP catalog 下指标数
+        assert df.shape[1] == 5
+        # 列降序 (最新在前)
+        col_years = [int(c.replace("年", "")) for c in df.columns]
+        assert col_years == sorted(col_years, reverse=True)
+        assert df.values.dtype.kind in "fi"  # numeric
+
+    def test_region_mode_a_loop_provinces(self):
+        df = macro_china_nbs_region(
+            kind="分省季度数据",
+            path="国民经济核算 > 地区生产总值",
+            indicator="地区生产总值累计值(亿元)",
+            period="LAST3",
+        )
+        assert df.shape[0] >= 30  # 31 省级单位
+        assert df.shape[1] >= 1
+        assert df.columns.name == "地区生产总值累计值(亿元)"
+        # 含非北京地区
+        assert "天津市" in df.index
+        assert "广东省" in df.index
+
+    def test_region_mode_b_all_indicators(self):
+        df = macro_china_nbs_region(
+            kind="分省季度数据",
+            path="国民经济核算 > 地区生产总值",
+            region="河北省",
+            period="LAST3",
+        )
+        assert df.shape[0] >= 1
+        assert df.columns.name == "河北省"
+
+    def test_region_mode_c_single(self):
+        df = macro_china_nbs_region(
+            kind="分省季度数据",
+            path="国民经济核算 > 地区生产总值",
+            indicator="地区生产总值累计值(亿元)",
+            region="天津市",
+            period="LAST3",
+        )
+        assert df.shape == (1, 3)
+        assert df.columns.name == "天津市"
+
+    def test_region_invalid_both_none(self):
+        with pytest.raises(ValueError, match="不能同时为 None"):
+            macro_china_nbs_region(
+                kind="分省季度数据",
+                path="国民经济核算 > 地区生产总值",
+                period="LAST3",
+            )
+
+    def test_path_invalid_middle_node(self):
+        with pytest.raises(ValueError, match="找不到"):
+            macro_china_nbs_nation(
+                kind="月度数据",
+                path="不存在分类 > 不存在指标",
+                period="LAST5",
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 背景

NBS (国家统计局) 在 2026 年 3 月 27 日推出新版数据发布库后, 老 `easyquery.htm`
端点被 WAF 拉黑名单 (响应头 `reason:UrlACL`), 任何 POST 请求被拦, 导致:

- `macro_china_nbs_nation` 全部失效
- `macro_china_nbs_region` 全部失效

报告 issues:

- Closes #7180
- Closes #7211
- Refs #7216 (已 closed, 同根问题)

## 修复

直连新版 `data.stats.gov.cn/dg/website/publicrelease/web/external/*` GUID API,
重写 `akshare/economic/macro_china_nbs.py`. **保留两个公开函数签名**
(`(kind, path, period)` / `(kind, path, indicator, region, period)`);
行为差异见下文.

实测主要事实 (写在代码注释 + docstring):

- 新 API 用 GUID 标识 catalog/indicator, path 中文名 → GUID 内部解析
- 显式数据区间 `dts` 必须是 JSON list (`["2018YY-2023YY"]`), 字符串形态被
  WAF 拒; latest 探测仍使用 `dts=""` 获取默认窗口
- 季度 dts 后缀是季度序号 01-04 (`202404SS` = Q4) 不是月份
- `daCatalogId` 必须传空字符串, 否则 NBS 忽略 das 走默认地区 (实测
  `daCatalogId=DC + das=[天津]` 返北京)
- 各 dataset 默认期数不同 (月度 13 / 季度 6 / 年度 10), 默认还包含未发布空期占位

## 设计取舍

新版 NBS API 用 GUID 标识 catalog/indicator. 一种选择是把 GUID 暴露给 akshare
用户 (新增 `macro_china_nbs_fetch(cid, indicator_ids, ...)` 等), 让老
`nation/region` deprecate. 本 PR 选择**保留老签名 + 内部 path → GUID 解析**, 理由:

- 三个 open issue 报的是老签名失效, path 兼容补丁是最直接的修复
- akshare 文档/示例/用户脚本都按 `(kind, path, period)` 写, GUID 化等于推翻
  整套对外 API
- akshare 主要用户是金融领域 Python 用户, 习惯 path 中文名调用
- GUID 是 NBS 后端实现细节, 暴露它会让 akshare 跟 NBS 后端 schema 强耦合

**代价**: path 是脆弱标识符 (NBS 改 catalog 中文名就挂); 性能比直接 GUID 调用慢
(walk 4-6 层树, 加 lru_cache 缓解). 这两点是已知妥协, 在代码注释里有标.

path 兼容这一层是长期价值 — 老用户代码不用改, 即便后端实现再换, 这一层屏蔽
内部细节. 直连 NBS 后端这一层有 NBS 端改版风险, 见下面「风险声明」.

## 超出本 PR 范围

本 PR 聚焦修三个 open issue, 以下方向虽然技术可行, 但不挤进本 PR:

- 暴露 GUID 体系新接口 (`macro_china_nbs_fetch` / `nbs_browse_tree`),
  供 power user 直接调用避开 path 解析
- 暴露新版 NBS 多出的 2 个 dataset ("三大经济体月度数据" / "主要国家年度数据")
- 跨切片自动 stitching (本 PR fail-fast)
- 接入 NBS `zxfb` (最新发布) / `sjgx` (数据解读) 文章流

## 行为差异 (诚实标注)

PR 保留对外签名, 但有几处行为细节跟 1.18.49 之前的输出微差:

1. **indicator label 缺下划线**

   老版输出 `地区生产总值_累计值(亿元)`, 新版 NBS API 字段 `i_showname` 是
   `地区生产总值累计值 (亿元) ` (无下划线). 没有可靠字段还原老版下划线位置,
   本 PR 输出 `地区生产总值累计值(亿元)`.

   用户用旧 label 做 `df.loc[name]` / index lookup 时会 KeyError; Mode A 的
   `df.columns.name` 也会少下划线.

2. **老版 2 段 path 命中 catalog 时 fail-fast**

   NBS 改版后某些 catalog 多了一层. 例: 老版
   `path="价格指数 > 居民消费价格分类指数(上年同月=100)"` 现在命中 L2 catalog
   (非 leaf), 该 catalog 下多了 "全国/城市/农村 × 时间切片" 共 21 个 leaf.
   现在会 fail-fast 列出 L+1 候选要求加层:

   ```python
   path = (
       "价格指数 > 居民消费价格分类指数(上年同月=100) > "
       "全国居民消费价格分类指数(上年同月=100)(2026-)"
   )
   ```

3. **LAST_N / 显式区间跨 NBS 时间切片时 fail-fast**

   NBS 把同一 indicator 拆成多个时间切片 leaf (例 CPI `(2026-)` /
   `(2021-2025)` / `(2016-2020)` / `(-2015)`). 本 PR 不做跨切片 stitching,
   period 跨切片时会 fail-fast 提示用户切到能覆盖 period 的切片. 默认 LAST_N
   会选开放右端切片 (例 `(2026-)`); 如果 LAST_N 落在该切片之前的期, 会报错
   要求显式选老切片.

4. **Mode A (region=None + indicator) 响应较慢**

   NBS 后端不支持单请求多地区, 必须串行循环逐省 fetch. 分省类 ~31 次 ≈ 5-10s,
   主要城市类视地区数可能更慢. 不并发避免触发 WAF.

5. **主要城市 `(2026-)` 切片地区列表为空时 fail-fast**

   实测主要城市月度价格的 `(2026-)` / `(2021-2025)` leaf 切片
   `getDasByDaCatalogId` 返 0 个地区, 老切片 `(2016-2020)` / `(-2015)` 才返
   36 城市. 现在 `_resolve_da_catalog` 拿到空地区 fail-fast, 错误信息提示
   用户改用更早期的切片.

## 兼容性说明

- 老版用户 path 中带行业子项的 (例
  `工业 > 工业分大类行业出口交货值(2018-至今) > 废弃资源综合利用业`),
  新版 NBS 把第 3 段也作为 path 节点, 本 PR 直接当 leaf 处理, 用户 path
  不需要改.
- nation / region 都是 catalog-level fetch (一次性拿 catalog 下所有
  indicator), 跟老版行为一致.

## 风险声明

NBS 官方公告 (2026-03-27) 明确说明新版数据发布库处于 **试运行期**, 后端 schema
可能继续变更:

> 近期国家统计局数据发布库进行了升级优化, 于 3 月 27 日正式推出新版国家统计局
> 数据发布库. **由于新系统上线仍有待实践检验, 为此新版国家统计局数据发布库上线
> 运行后将设置一段试运行期.**
>
> ——[《关于新版国家统计局数据发布库上线的公告》](https://www.stats.gov.cn/xw/tjxw/tzgg/202603/t20260325_1962844.html), 国家统计局, 2026-03-27

本 PR 已对几类已知陷阱做了 fail-fast (而不是静默返错):

- WAF 拦截 (返 HTML 而非 JSON) → 抛 RuntimeError 提示 dts 必须 list
- 跨 leaf 时间切片 → 抛 ValueError 提示用户切到合适切片
- 地区列表为空 → 抛 ValueError 提示改用更早期切片
- path 命中 catalog 非 leaf → 抛 ValueError 列出 L+1 候选

但**不能保证 NBS 后端再改时本 PR 仍能跑**. 试运行期间如果遇到下面情况, 需要
再发补丁修:

- NBS 把 `/dg/website/publicrelease/web/external/*` 路径改名 → 全部失效
- NBS 把 `getEsDataByCidAndDt` 的 payload schema 调整 (例 das 字段名变) →
  fetch 失效
- NBS 把 catalog 树结构再调整 (例 CPI 再多一层) → path 解析失败

当前 PR 已尽量把对 NBS 后端 schema 的假设集中在:

- 模块顶部常量 (`_DATASETS` / `_KIND_TO_SUFFIX` / `_HTTP_HEADERS`)
- 内部 helper (`_query_tree` / `_resolve_da_catalog` / `_fetch_data`)

后续修补面较小. NBS 官方提供反馈渠道 (010-68576320 / info@stats.gov.cn),
社区也可在 akshare 这里 issue 提.

## 手动验证输出

### Q1: Nation 月度 CPI / period="2024" / base-name fallback 选中 (2021-2025) 切片

```python
df = ak.macro_china_nbs_nation(
    kind="月度数据",
    path="价格指数 > 居民消费价格分类指数(上年同月=100) > 全国居民消费价格分类指数(上年同月=100)",
    period="2024",
)
# shape=(13, 12), columns=['2024年12月', ..., '2024年1月'] (列降序最新在前)
```

### Q2: Nation 年度 GDP / LAST5

```
                 2025年      2024年      2023年      2022年      2021年
国民总收入(亿元)   1394052.90 1340429.00 1284773.90 1223706.80 1165816.80
国内生产总值(亿元)  1401879.20 1348066.20 1294271.70 1234029.40 1173823.00
第一产业增加值(亿元)   93346.80   91635.80   89169.10   88207.00   83216.50
第二产业增加值(亿元)  499653.00  490305.40  475936.10  467629.60  447138.20
第三产业增加值(亿元)  808879.30  766124.90  729166.50  678192.70  643468.40
人均国内生产总值(元)   99665.00   95677.00   91746.00   87385.00   83111.00
```

### Q3: Region Mode A / 31 省 GDP / last3

```
地区生产总值累计值(亿元)  2026年第一季度  2025年第四季度  2025年第三季度
北京市                12931      52073      38320
天津市                 4370      18540      13360
河北省                11748      49305      35523
...
新疆维吾尔自治区          4826      21462      15552
```

shape=(31, 3), `df.columns.name='地区生产总值累计值(亿元)'`

### Q4: Region Mode B / 河北省 全部 indicator / last3

```
河北省                       2026年第一季度  2025年第四季度  2025年第三季度
地区生产总值累计值(亿元)              11748.00   49305.00   35523.00
地区生产总值指数(上年同期=100)累计值(%)     104.90     105.60     105.50
```

### Q5: Region Mode C / 天津市 + 单 indicator / 2018-2023

shape=(1, 24), columns 从 `2023年第四季度` 降序到 `2018年第一季度`,
24 个季度全部覆盖 2018-2023 闭区间.

## 测试

新增 `tests/test_macro_china_nbs.py`:

- 54 个纯单元测试 (period parser / NBS code 转换 / dts 越界 / 跨切片
  fail-fast / normalize 等)
- 6 个联网 smoke (默认 skip, `AKSHARE_NETWORK_TESTS=1` 启用)

```bash
$ pytest tests/test_macro_china_nbs.py -q
54 passed, 6 skipped in 0.34s

$ AKSHARE_NETWORK_TESTS=1 pytest tests/test_macro_china_nbs.py -q
60 passed in 5.39s
```

`tests/test_func.py` 现有 2 测试仍过, ruff check / format 全清.

## 文件改动

- `akshare/economic/macro_china_nbs.py`: 293 → 约 1.1k 行 (重写)
- `tests/test_macro_china_nbs.py`: 新增约 400 行 / 60 测试

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
