### PR TITLE
fix: handle dsc field in stock_individual_info_em

### DIFF
--- a/akshare/stock/stock_info_em.py
+++ b/akshare/stock/stock_info_em.py
@@ -61,6 +61,8 @@ def stock_individual_info_em(
     temp_df = temp_df[pd.notna(temp_df["index"])]
     if "dlmkts" in temp_df.columns:
         del temp_df["dlmkts"]
+    if "dsc" in temp_df.columns:
+        del temp_df["dsc"]
     temp_df.columns = [
         "item",
         "value",


### PR DESCRIPTION
Fixes #7286.

Eastmoney's `stock/get` response can include a top-level `dsc` field. `stock_individual_info_em` currently removes several metadata columns before renaming the remaining columns to `item` and `value`, but it does not remove `dsc`. When `dsc` is present, the DataFrame has three columns and the rename raises:

`ValueError: Length mismatch: Expected axis has 3 elements, new values have 2 elements`

This change drops `dsc` when present, matching the existing handling for `dlmkts`.