### PR TITLE
fix: handle empty cninfo disclosure results

### DIFF
--- a/akshare/stock_feature/stock_disclosure_cninfo.py
+++ b/akshare/stock_feature/stock_disclosure_cninfo.py
@@ -153,6 +153,10 @@ def stock_zh_a_disclosure_report_cninfo(
         text_json = r.json()
         temp_df = pd.DataFrame(text_json["announcements"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
+    if big_df.empty:
+        return pd.DataFrame(
+            columns=["代码", "简称", "公告标题", "公告时间", "公告链接"]
+        )
     big_df.rename(
         columns={
             "secCode": "代码",
@@ -248,6 +252,10 @@ def stock_zh_a_disclosure_relation_cninfo(
         text_json = r.json()
         temp_df = pd.DataFrame(text_json["announcements"])
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
+    if big_df.empty:
+        return pd.DataFrame(
+            columns=["代码", "简称", "公告标题", "公告时间", "公告链接"]
+        )
     big_df.rename(
         columns={
             "secCode": "代码",


### PR DESCRIPTION
### Summary
- return an empty DataFrame with the documented output columns when CNInfo reports zero announcements
- avoid a KeyError when the CNInfo disclosure report and relation helpers filter columns on an empty result set

### Test
- Reproduced #7251 with `stock_zh_a_disclosure_report_cninfo(symbol="600036", market="沪深京", category="风险提示", start_date="20200101", end_date="20260428")`; CNInfo returned `totalAnnouncement: 0` and `announcements: null`