### PR TITLE
fix: handle empty paginated data

### DIFF
--- a/akshare/utils/func.py
+++ b/akshare/utils/func.py
@@ -34,12 +34,15 @@ def fetch_paginated_data(url: str, base_params: Dict, timeout: int = 15):
     r = request_with_retry(url, params=params, timeout=timeout)
     data_json = r.json()
     # 计算分页信息
-    per_page_num = len(data_json["data"]["diff"])
+    first_page_data = data_json["data"]["diff"]
+    if not first_page_data:
+        return pd.DataFrame(data=[])
+    per_page_num = len(first_page_data)
     total_page = math.ceil(data_json["data"]["total"] / per_page_num)
     # 存储所有页面数据
     temp_list = []
     # 添加第一页数据
-    temp_list.append(pd.DataFrame(data_json["data"]["diff"]))
+    temp_list.append(pd.DataFrame(first_page_data))
     # 获取进度条
     tqdm = get_tqdm()
     # 获取剩余页面数据

--- a/tests/test_utils_func.py
+++ b/tests/test_utils_func.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+import pandas as pd
+
+from akshare.utils import func as utils_func
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_paginated_data_empty_result(monkeypatch):
+    def fake_request_with_retry(url, params, timeout):
+        return _Response({"data": {"diff": [], "total": 0}})
+
+    monkeypatch.setattr(utils_func, "request_with_retry", fake_request_with_retry)
+
+    result = utils_func.fetch_paginated_data("https://example.test/api", {"pn": 1})
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty


### PR DESCRIPTION
## Summary
- return an empty DataFrame when the first paginated response contains no records
- avoid dividing by zero when `data.diff` is empty
- add an offline regression test for the empty-result response shape

## Verification
- RED: `.venv/bin/python -m pytest tests/test_utils_func.py -q` failed with `ZeroDivisionError: division by zero`
- GREEN: `.venv/bin/python -m pytest tests/test_utils_func.py tests/test_func.py -q` passed, 3 tests
- `.venv/bin/python -m py_compile akshare/utils/func.py tests/test_utils_func.py tests/test_func.py` passed
- `git diff --check` passed

Note: I used a local `.venv` with project dependencies for verification; generated environment/cache files are ignored and not included.