### PR TITLE
fix: stock_sector_fund_flow_rank 优雅处理新板块返回 '-' 的情况

### DIFF
--- a/akshare/stock/stock_fund_em.py
+++ b/akshare/stock/stock_fund_em.py
@@ -506,7 +506,7 @@ def stock_sector_fund_flow_rank(
                 "pn": page,
             }
         )
-        r = requests.get(url, params=params, timeout=15)
+        r = requests.get(url, params=params, headers=headers, timeout=15)
         data_json = r.json()
         inner_temp_df = pd.DataFrame(data_json["data"]["diff"])
         temp_list.append(inner_temp_df)
@@ -551,9 +551,9 @@ def stock_sector_fund_flow_rank(
                 "今日主力净流入最大股",
             ]
         ]
-        temp_df["今日主力净流入-净额"] = pd.to_numeric(
-            temp_df["今日主力净流入-净额"], errors="coerce"
-        )
+        for col in temp_df.columns:
+            if col not in ("名称", "今日主力净流入最大股"):
+                temp_df[col] = pd.to_numeric(temp_df[col], errors="coerce")
         temp_df.sort_values(["今日主力净流入-净额"], ascending=False, inplace=True)
         temp_df.reset_index(inplace=True)
         temp_df["index"] = range(1, len(temp_df) + 1)
@@ -597,6 +597,9 @@ def stock_sector_fund_flow_rank(
                 "5日主力净流入最大股",
             ]
         ]
+        for col in temp_df.columns:
+            if col not in ("名称", "5日主力净流入最大股"):
+                temp_df[col] = pd.to_numeric(temp_df[col], errors="coerce")
         temp_df.sort_values(["5日主力净流入-净额"], ascending=False, inplace=True)
         temp_df.reset_index(inplace=True)
         temp_df["index"] = range(1, len(temp_df) + 1)
@@ -640,6 +643,9 @@ def stock_sector_fund_flow_rank(
                 "10日主力净流入最大股",
             ]
         ]
+        for col in temp_df.columns:
+            if col not in ("名称", "10日主力净流入最大股"):
+                temp_df[col] = pd.to_numeric(temp_df[col], errors="coerce")
         temp_df.sort_values(["10日主力净流入-净额"], ascending=False, inplace=True)
         temp_df.reset_index(inplace=True)
         temp_df["index"] = range(1, len(temp_df) + 1)


### PR DESCRIPTION
## 关联 Issue

修复 #7303

## 问题

当天新上线的板块（如 BK1710 先进制造风格等）在东财接口中所有数值字段返回 `'-'`，导致 `stock_sector_fund_flow_rank` 在数值转换/排序时报错：

```
Could not convert '-' with type str: tried to convert to double
```

## 修改

1. **三个 indicator 分支（今日/5日/10日）统一对所有数值列做 `pd.to_numeric(errors='coerce')`**：原代码仅「今日」分支对「净额」一列做了 coerce，其余数值列遇 `'-'` 仍是字符串；「5日/10日」分支甚至直接对 object 列排序。修复后新板块行数值字段为 NaN，不再报错，调用方可自行 `dropna` 过滤
2. **顺手修复分页请求丢失 headers 的问题**：循环翻页的 `requests.get` 没有传 `headers`（首次请求有 User-Agent，翻页没有），容易被服务端拒绝导致 JSONDecodeError

## 验证

用模拟的「正常板块 + 全 '-' 新板块」数据对今日/5日/10日三个分支做了离线测试：数值列全部为 float dtype、新板块行为 NaN、排序正常、行数不丢失。

## AI 辅助说明

本 PR 由 Claude Code 辅助完成（代码与描述），已经过上述测试验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)