### PR TITLE
fix: stock_research_report_em 在标的无研报时返回空 DataFrame

### DIFF
--- a/akshare/stock_feature/stock_research_report_em.py
+++ b/akshare/stock_feature/stock_research_report_em.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 """
-Date: 2025/2/28 13:00
+Date: 2026/6/14 10:00
 Desc: 东方财富网-数据中心-研究报告-个股研报
 https://data.eastmoney.com/report/stock.jshtml
 """
@@ -60,6 +60,11 @@ def stock_research_report_em(symbol: str = "000001") -> pd.DataFrame:
         data_json = r.json()
         temp_df = pd.DataFrame(data_json["data"])
         big_df = pd.concat(objs=[big_df, temp_df], axis=0, ignore_index=True)
+
+    # 检查 DataFrame 是否为空（该股票暂无研报时，接口返回 TotalPage 为 0）
+    if big_df.empty:
+        return pd.DataFrame()
+
     big_df.reset_index(inplace=True)
     big_df["index"] = big_df["index"] + 1
     predict_this_year_eps_title = f"{current_year}-盈利预测-收益"


### PR DESCRIPTION
东方财富研报列表接口在某股票暂无研报时返回 TotalPage=0，分页循环不执行，
big_df 仍是空且无任何列，后续 big_df["infoCode"] 直接 KeyError。 在拼接完所有分页结果后补充空判断，与 stock_lhb_em 等函数保持一致，
直接返回空 DataFrame。