### PR TITLE
fix: fix stock_rank_cxd_ths interface

### DIFF
--- a/akshare/stock_feature/stock_technology_ths.py
+++ b/akshare/stock_feature/stock_technology_ths.py
@@ -158,7 +158,7 @@ def stock_rank_cxd_ths(symbol: str = "创月新低") -> pd.DataFrame:
             f"stockcode/order/asc/page/{page}/ajax/1/free/1/"
         )
         r = requests.get(url, headers=headers)
-        temp_df = pd.read_html(StringIO(r.text))[0].iloc[:, :-1]  # 20260214 新增
+        temp_df = pd.read_html(StringIO(r.text))[0]
         big_df = pd.concat(objs=[big_df, temp_df], ignore_index=True)
     big_df.columns = [
         "序号",


### PR DESCRIPTION
`stock_rank_cxd_ths` (创新低 / new-low) raises:

```
ValueError: Length mismatch: Expected axis has 7 elements, new values have 8 elements
```

同花顺 changed the new-low table so `pd.read_html` now returns the expected 8
columns directly. The leftover `.iloc[:, :-1]` slice drops one of them, leaving
7, so the 8-name assignment fails.

Removing the slice keeps all 8 columns (the same handling already applied to the
sibling `stock_rank_cxg_ths`):

```diff
-        temp_df = pd.read_html(StringIO(r.text))[0].iloc[:, :-1]  # 20260214 新增
+        temp_df = pd.read_html(StringIO(r.text))[0]
```

Verified live against the current source: `stock_rank_cxd_ths("创月新低")`
returns 1154 rows with the expected 8 columns
(序号, 股票代码, 股票简称, 涨跌幅, 换手率, 最新价, 前期低点, 前期低点日期).
