### PR TITLE
fix: stock_zh_a_hist_tx mislabels 成交量 as amount; recover real 成交额 and 换手率

### DIFF
--- a/akshare/stock_feature/stock_hist_tx.py
+++ b/akshare/stock_feature/stock_hist_tx.py
@@ -36,7 +36,7 @@ def stock_zh_a_hist_tx(
     :type adjust: str
     :param timeout: choice of None or a positive float number
     :type timeout: float
-    :return: 前复权的股票和指数数据
+    :return: 股票和指数历史行情数据, 复权方式由 adjust 参数决定(默认不复权); 成交量统一为股, 成交额统一为元
     :rtype: pandas.DataFrame
     """
     init_start_date = get_tx_start_year(symbol=symbol)
@@ -68,15 +68,27 @@ def stock_zh_a_hist_tx(
         else:
             temp_df = pd.DataFrame(data_json["qfqday"])
         big_df = pd.concat([big_df, temp_df], ignore_index=True)
-    big_df = big_df.iloc[:, :6]
-    big_df.columns = ["date", "open", "close", "high", "low", "amount"]
+    # 行情列表结构: [日期, 开盘, 收盘, 最高, 最低, 成交量(手; 科创板为股), {}, 换手率(%), 成交额(万元), ...]
+    # 此前误将第 5 列(成交量)命名为 amount 并丢弃了真实的成交额(第 8 列)与换手率(第 7 列)
+    big_df = big_df.reindex(columns=[0, 1, 2, 3, 4, 5, 7, 8])
+    big_df.columns = [
+        "date",
+        "open",
+        "close",
+        "high",
+        "low",
+        "volume",
+        "turnover",
+        "amount",
+    ]
     big_df["date"] = pd.to_datetime(big_df["date"], errors="coerce").dt.date
-    big_df["open"] = pd.to_numeric(big_df["open"], errors="coerce")
-    big_df["close"] = pd.to_numeric(big_df["close"], errors="coerce")
-    big_df["high"] = pd.to_numeric(big_df["high"], errors="coerce")
-    big_df["low"] = pd.to_numeric(big_df["low"], errors="coerce")
-    big_df["amount"] = pd.to_numeric(big_df["amount"], errors="coerce")
-    big_df.drop_duplicates(inplace=True, ignore_index=True)
+    for col in ["open", "close", "high", "low", "volume", "turnover", "amount"]:
+        big_df[col] = pd.to_numeric(big_df[col], errors="coerce")
+    if not symbol.startswith("sh68"):  # 统一成交量单位为股: 科创板原生为股, 其余板块原生为手
+        big_df["volume"] = big_df["volume"] * 100  # 手 -> 股
+    big_df["amount"] = big_df["amount"] * 10000  # 万元 -> 元
+    # 分页窗口重叠会产生重复日期; 按 date 去重(不同年代的行宽不同, 整行比较可能漏去重)
+    big_df.drop_duplicates(subset=["date"], keep="last", inplace=True, ignore_index=True)
     big_df.index = pd.to_datetime(big_df["date"], errors="coerce")
     big_df.sort_index(inplace=True)
     big_df = big_df[start_date:end_date]


### PR DESCRIPTION
## 问题

`stock_zh_a_hist_tx` 将腾讯接口返回行截断为前 6 列, 并把第 5 列命名为 `amount` — 但该列实际是**成交量**, 真实的成交额(第 8 列, 万元)和换手率(第 7 列)被丢弃。此外腾讯原生成交量单位随板块不同: 主板/创业板为**手**, 科创板为**股**。

## 证据 (sh600000, 2024-06-05)

| 量 | 值 |
|---|---|
| 旧接口 `amount` 列 | 312,958 |
| 真实成交量 (新浪, 股) | 31,295,787 = 312,958 手 ✓ |
| 真实成交额 (新浪, 元) | 259,659,811 |
| 旧 `amount` 与真实成交额比值 | ≈ 830 = close(8.29) × 100 — 即该列是手数而非金额 |

科创板单位验证: sh688981 2024-06-03 腾讯成交量 39,368,171 与新浪股数完全一致(原生即为股); sh600000/sz300750 则需 ×100 才一致(原生为手)。

## 修复

- 保留第 0–5, 7, 8 列, 命名为 `date, open, close, high, low, volume, turnover, amount`;
- **单位统一**: `volume` 统一为**股**(非科创板 ×100), `amount` 万元 → **元**;
- docstring 注明统一后的单位。

## 验证

不复权 / hfq / 指数(sh000919) 调用均通过; 成交量与新浪逐日一致(600000: 60,213,700 股; 688981: 39,368,171 股); 成交额与新浪一致(万元精度); 换手率与 成交量÷流通股本 一致。

⚠️ 兼容性: 旧 `amount` 列语义错误, 本 PR 将其修正为真实成交额; `volume` 统一为股 — 依赖旧列的用户代码需相应调整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CA5ZD3MmTLix5mtV29jdGq
