### PR TITLE
fix: stock_zh_a_gbjg_em silently truncates 股本结构 history to 20 rows

### DIFF
--- a/akshare/stock_fundamental/stock_gbjg_em.py
+++ b/akshare/stock_fundamental/stock_gbjg_em.py
@@ -32,16 +32,27 @@ def stock_zh_a_gbjg_em(symbol: str = "603392.SH") -> pd.DataFrame:
         "quoteColumns": "",
         "filter": f'(SECUCODE="{symbol}")',
         "pageNumber": "1",
-        "pageSize": "20",
+        "pageSize": "500",
         "sortTypes": "-1",
         "sortColumns": "END_DATE",
         "source": "HSF10",
         "client": "PC",
         "v": "047483522105257925",
     }
-    r = requests.get(url, params=params)
-    data_json = r.json()
-    temp_df = pd.DataFrame(data_json["result"]["data"])
+    # 分页获取全部股本变动历史; 此前固定 pageSize=20 只返回最近 20 条
+    big_df = pd.DataFrame()
+    while True:
+        r = requests.get(url, params=params)
+        data_json = r.json()
+        if not (data_json.get("result") and data_json["result"]["data"]):
+            break
+        big_df = pd.concat(
+            [big_df, pd.DataFrame(data_json["result"]["data"])], ignore_index=True
+        )
+        if int(params["pageNumber"]) >= int(data_json["result"].get("pages", 1)):
+            break
+        params["pageNumber"] = str(int(params["pageNumber"]) + 1)
+    temp_df = big_df
     temp_df.rename(
         columns={
             "END_DATE": "变更日期",


### PR DESCRIPTION
## 问题

`stock_zh_a_gbjg_em` 固定 `pageSize=20` 且只取第一页 — 股本变更超过 20 条的股票(绝大多数老股票)的早期历史被**静默截断**, 调用方无从察觉。

例: `600000.SH` 实际有 **69** 条股本变更记录(最早 1999-09-23 上市前股本), 旧实现只返回最近 20 条。

## 修复

按响应 `result.pages` 分页拉取全部记录(`pageSize=500`), 输出列与原先一致, 仅行数变全。

## 验证

`stock_zh_a_gbjg_em('600000.SH')` → 69 行, 首尾记录与东方财富 F10 股本结构页一致; 短历史股票(不足一页)行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CA5ZD3MmTLix5mtV29jdGq