### PR TITLE
fix: remove invalid suffix from secids parameter in stock_hot_rank_em (closes #7346)

### DIFF
--- a/akshare/stock/stock_hot_rank_em.py
+++ b/akshare/stock/stock_hot_rank_em.py
@@ -39,7 +39,7 @@ def stock_hot_rank_em() -> pd.DataFrame:
         "fltt": "2",
         "invt": "2",
         "fields": "f14,f3,f12,f2",
-        "secids": ",".join(temp_rank_df["mark"]) + ",?v=08926209912590994",
+        "secids": ",".join(temp_rank_df["mark"]),
     }
     url = "https://push2.eastmoney.com/api/qt/ulist.np/get"
     r = requests.get(url, params=params)


### PR DESCRIPTION
## What
The `stock_hot_rank_em` function constructs a `secids` parameter with an invalid trailing `,?v=08926209912590994`. This string is not a valid security ID and may cause the API to fail or return unexpected results.

## Fix
Remove the extraneous `,?v=08926209912590994` suffix from the `secids` parameter. The comma-joined list of market codes is sufficient for the API request.

Closes #7346