### PR TITLE
fix(index_all_cni): align column count with current cnindex API response

### DIFF
--- a/akshare/index/index_cni.py
+++ b/akshare/index/index_cni.py
@@ -55,6 +55,7 @@ def index_all_cni() -> pd.DataFrame:
         "_",
         "_",
         "_",
+        "_",
     ]
     temp_df = temp_df[
         [
@@ -237,7 +238,7 @@ if __name__ == "__main__":
     index_detail_cni_df = index_detail_cni(symbol="399001")
     print(index_detail_cni_df)
 
-    index_detail_hist_cni_df = index_detail_hist_cni(symbol="399101", date="202404")
+    index_detail_hist_cni_df = index_detail_hist_cni(symbol="399101")
     print(index_detail_hist_cni_df)
 
     index_detail_hist_adjust_cni_df = index_detail_hist_adjust_cni(symbol="399005")


### PR DESCRIPTION
fix(index_all_cni): align columns with cnindex API

复现问题：ak.index_all_cni() 报 Length mismatch
原因：接口返回 26 列，但代码只指定 25 列名
修复：补齐列名 / 修正字段映射
