### PR TITLE
fix: handle empty concept board history responses

### DIFF
--- a/akshare/stock/stock_board_concept_em.py
+++ b/akshare/stock/stock_board_concept_em.py
@@ -228,8 +228,7 @@ def stock_board_concept_hist_em(
     }
     r = requests.get(url, params=params)
     data_json = r.json()
-    temp_df = pd.DataFrame([item.split(",") for item in data_json["data"]["klines"]])
-    temp_df.columns = [
+    raw_columns = [
         "日期",
         "开盘",
         "收盘",
@@ -242,6 +241,24 @@ def stock_board_concept_hist_em(
         "涨跌额",
         "换手率",
     ]
+    columns = [
+        "日期",
+        "开盘",
+        "收盘",
+        "最高",
+        "最低",
+        "涨跌幅",
+        "涨跌额",
+        "成交量",
+        "成交额",
+        "振幅",
+        "换手率",
+    ]
+    data = data_json.get("data") if isinstance(data_json, dict) else None
+    if not isinstance(data, dict) or not data.get("klines"):
+        return pd.DataFrame(columns=columns)
+    temp_df = pd.DataFrame([item.split(",") for item in data["klines"]])
+    temp_df.columns = raw_columns
     temp_df = temp_df[
         [
             "日期",

--- a/tests/test_stock_board_concept_em.py
+++ b/tests/test_stock_board_concept_em.py
@@ -1,0 +1,77 @@
+import pandas as pd
+import pytest
+
+import akshare.stock.stock_board_concept_em as concept_em
+
+
+EXPECTED_HIST_COLUMNS = [
+    "日期",
+    "开盘",
+    "收盘",
+    "最高",
+    "最低",
+    "涨跌幅",
+    "涨跌额",
+    "成交量",
+    "成交额",
+    "振幅",
+    "换手率",
+]
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def json(self):
+        return self.payload
+
+
+def test_board_code_does_not_require_name_lookup(monkeypatch):
+    monkeypatch.setattr(
+        concept_em,
+        "__stock_board_concept_name_em",
+        lambda: pytest.fail("board codes should bypass the name lookup"),
+    )
+    monkeypatch.setattr(
+        concept_em.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(
+            {
+                "data": {
+                    "klines": [
+                        "2025-01-01,1,2,3,0,10,20,4,5,1,0.1",
+                    ]
+                }
+            }
+        ),
+    )
+
+    result = concept_em.stock_board_concept_hist_em(symbol="BK1676")
+
+    assert list(result.columns) == EXPECTED_HIST_COLUMNS
+    assert result.loc[0, "收盘"] == 2
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"data": None},
+        {},
+        {"data": {}},
+        {"data": {"klines": None}},
+        {"data": {"klines": []}},
+    ],
+)
+def test_empty_or_invalid_response_returns_schema(monkeypatch, payload):
+    monkeypatch.setattr(
+        concept_em.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(payload),
+    )
+
+    result = concept_em.stock_board_concept_hist_em(symbol="BK1676")
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert list(result.columns) == EXPECTED_HIST_COLUMNS


### PR DESCRIPTION
## What changed

`stock_board_concept_hist_em` now returns an empty DataFrame with its documented output schema when EastMoney returns no usable history payload:

- response is not a JSON object
- `data` is missing or `null`
- `klines` is missing, `null`, or empty

Normal non-empty responses follow the existing parsing and numeric-conversion path unchanged. Malformed non-empty rows also remain strict.

## Why

The current implementation indexes `data_json["data"]["klines"]` directly. Temporary upstream empty responses therefore raise `KeyError`, `TypeError`, or a pandas column-length `ValueError` instead of producing the same schema users receive for successful calls.

This is the same failure class reported historically in #6073 and #6133. Board-code lookup itself is already handled by the current implementation and is not changed here.

## Validation

- Focused offline regression tests: `6 passed`
- Full repository test suite: `85 passed`
- Ruff check: passed
- Ruff format check: passed
- `git diff --check`: passed

All regression tests mock the HTTP response and require no network access.

## Compatibility and risk

Low. Successful responses are unchanged. Empty upstream responses now return a schema-correct empty DataFrame instead of raising an implementation exception.
